### PR TITLE
6 break not added to event if set outside init

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,7 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": {
 		"1": "conda install -y python=3.11.8 && conda install -y -c conda-forge cvxopt && conda install -y -c conda-forge pygraphviz && pip3 install --user -r requirements.txt && bash scripts/install_repositories.sh",
-		"2": "echo 'export PYTHONPATH=/workspaces/erebus:$PYTHONPATH' >> ~/.bashrc"
+		"2": "echo 'export PYTHONPATH=${containerWorkspaceFolder}:$PYTHONPATH' >> ~/.bashrc"
 	},
 	// Add repo to safe directories
 	"postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",

--- a/tel2puml/puml_graph/graph.py
+++ b/tel2puml/puml_graph/graph.py
@@ -202,7 +202,7 @@ class PUMLEventNode(PUMLNode):
             )
         blocks = []
         blocks.append(f"{' ' * indent}:{self.node_type}{branch_info};")
-        if self.extra_info.get("is_break", False):
+        if PUMLEvent.BREAK in self.event_types:
             blocks.append(f"{' ' * indent}break")
         return blocks
 

--- a/tests/tel2puml/puml_graph/test_graph.py
+++ b/tests/tel2puml/puml_graph/test_graph.py
@@ -87,6 +87,12 @@ class TestPUMLEventNode:
         assert break_event.write_uml_blocks(indent=4, tab_size=4) == (
             ["    :event;", "    break"], 0
         )
+        # check case where Break event type is added after init
+        break_event = PUMLEventNode("event", 0)
+        break_event.event_types = (PUMLEvent.BREAK,)
+        assert break_event.write_uml_blocks(indent=4, tab_size=4) == (
+            ["    :event;", "    break"], 0
+        )
 
     @staticmethod
     def test_write_uml_block_sub_graph() -> None:


### PR DESCRIPTION
PR to fix bug in which `break` line was not added to PUML if the event types are altered after initialisation

Also removed reference to erebus in setting of pythonpath in devcontainer