### PR TITLE
33 update to use only pip to install

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,55 +1,61 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
-	"name": "Test Harness",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/anaconda:0.204.15-3",
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	"features": {
-		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-			"packages": "default-jre"
-		}
-	},
-	"customizations": {
-		"vscode": {
-			"settings": {
-				"black-formatter.args": [
-					"--preview",
-					"--line-length",
-					"79"
-				],
-				"[python]": {
-					"editor.rulers": [
-						{
-							"column": 79
-						}
-					]
-				}
-			},
-			"extensions": [
-				"ms-python.black-formatter",
-				"ms-python.vscode-pylance",
-				"ms-python.python",
-				"GitHub.copilot-chat",
-				"GitHub.copilot"
-			]
-		}
-	},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": {
-		"1": "conda install -y python=3.11.8 && conda install -y -c conda-forge cvxopt && conda install -y -c conda-forge pygraphviz && pip3 install --user -r requirements.txt && bash scripts/install_repositories.sh",
-		"2": "echo 'export PYTHONPATH=${containerWorkspaceFolder}:$PYTHONPATH' >> ~/.bashrc"
-	},
-	// Add repo to safe directories
-	"postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
-	// Configure tool-specific properties.
-	// "customizations": {},
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
-	"mounts": [
-		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
-		// "source=${localEnv:HOME}${localEnv:USERPROFILE}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached"
-	]
+    "name": "Test Harness",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+        "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+            "packages": [
+                "liblapack-dev",
+                "libopenblas-dev",
+                "libsuitesparse-dev",
+                "libglpk-dev",
+                "default-jre"
+            ]
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "black-formatter.args": [
+                    "--preview",
+                    "--line-length",
+                    "79"
+                ],
+                "[python]": {
+                    "editor.rulers": [
+                        {
+                            "column": 79
+                        }
+                    ]
+                }
+            },
+            "extensions": [
+                "ms-python.black-formatter",
+                "ms-python.vscode-pylance",
+                "ms-python.python",
+                "GitHub.copilot-chat",
+                "GitHub.copilot"
+            ]
+        }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": {
+        "1": "export CPPFLAGS='-I/usr/include/suitesparse' && export CVXOPT_BUILD_GLPK=1 && pip install -r requirements.txt && bash scripts/install_repositories.sh",
+        "2": "echo 'export PYTHONPATH=${containerWorkspaceFolder}:$PYTHONPATH' >> ~/.bashrc"
+    },
+    // Add repo to safe directories
+    "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+    // Configure tool-specific properties.
+    // "customizations": {},
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root",
+    "mounts": [
+        "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
+        // "source=${localEnv:HOME}${localEnv:USERPROFILE}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached"
+    ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
-    "name": "Test Harness",
+    "name": "Otel2Puml",
     // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
     "image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
     // Features to add to the dev container. More info: https://containers.dev/features.

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          pytest tests/end_to_end_tests
+          pytest ${GITHUB_WORKSPACE}/tests/end_to_end_tests
 
   run-tests-check-no-anaconda-mac-os:
     runs-on: macos-latest
@@ -125,4 +125,4 @@ jobs:
 
       - name: Run Tests
         run: |
-          pytest tests/end_to_end_tests
+          pytest ${GITHUB_WORKSPACE}/tests/end_to_end_tests

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -48,11 +48,8 @@ jobs:
         run: |
           export PIP_CONSTRAINT='pip_constraint.txt'
           pip install --upgrade pip
-
-          pip install pytest
-          pytest --version
-
           pip install -r requirements.txt
+          pytest --version
 
       - name: Run Tests
         run: |
@@ -95,7 +92,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          pytest ${GITHUB_WORKSPACE}/tests/end_to_end_tests
+          pytest
 
   run-tests-check-no-anaconda-mac-os:
     runs-on: macos-latest
@@ -125,4 +122,4 @@ jobs:
 
       - name: Run Tests
         run: |
-          pytest ${GITHUB_WORKSPACE}/tests/end_to_end_tests
+          pytest

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -61,6 +61,9 @@ jobs:
   run-tests-check-no-anaconda-linux:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Checkout
+        uses: actions/checkout@v4
+      
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -97,6 +100,9 @@ jobs:
   run-tests-check-no-anaconda-mac-os:
     runs-on: macos-latest
     steps:
+      - name: Setup Checkout
+        uses: actions/checkout@v4
+      
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -29,7 +29,7 @@ jobs:
         uses: s-weigand/setup-conda@v1
         with:
           update-conda: true
-          python-version: 3.11.8
+          python-version: 3.11.9
           conda-channels: conda-forge
 
       - name: Install pre-requisites
@@ -57,3 +57,66 @@ jobs:
       - name: Run Tests
         run: |
           pytest
+  
+  run-tests-check-no-anaconda-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11.9'
+          cache: 'pip'
+
+      - name: Install pre-requisites
+        run: |
+          sudo apt update
+          sudo apt install -y liblapack-dev libblas-dev
+          sudo apt install -y libsuitesparse-dev
+          sudo apt install -y libsuitesparse-dev
+
+      - name: Install janus and erebus as packages
+        run: |
+          chmod +x ./scripts/install_repositories.sh && ./scripts/install_repositories.sh
+      
+      - name: Add GitHub workspace to PYTHONPATH
+        run: echo "PYTHONPATH=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
+      
+      - name: Install Requirements
+        run: |
+          export PIP_CONSTRAINT='pip_constraint.txt'
+          pip install --upgrade pip
+          export CPPFLAGS="-I/usr/include/suitesparse"
+          export CVXOPT_BUILD_GLPK=1
+          pip install -r requirements.txt
+          pytest --version
+
+      - name: Run Tests
+        run: |
+          pytest tests/end_to_end_tests
+
+  run-tests-check-no-anaconda-mac-os:
+    runs-on: macos-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11.9'
+          cache: 'pip'
+
+      - name: Install janus and erebus as packages
+        run: |
+          chmod +x ./scripts/install_repositories.sh && ./scripts/install_repositories.sh
+      
+      - name: Add GitHub workspace to PYTHONPATH
+        run: echo "PYTHONPATH=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
+      
+      - name: Install Requirements
+        run: |
+          export PIP_CONSTRAINT='pip_constraint.txt'
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pytest --version
+
+      - name: Run Tests
+        run: |
+          pytest tests/end_to_end_tests

--- a/README.md
+++ b/README.md
@@ -117,12 +117,24 @@ There are two ways to set up this project: manual installation or using a devcon
 
 ### Manual Installation
 
+The project can be installed manually in a few different ways. Make sure you have the following prerequisites for all installation methods:
+* `git`
+* Python version 3.11.9 or lower
+* `bash`
+* `pip` (Python package manager)
+
+(OPTIONAL) If you want to use the following functions:
+* `tel2puml.events.save_vis_logic_gate_tree`
+* `tel2puml.utils.get_graphviz_plot`
+you will also need:
+* Java runtime environment (can be installed via `apt install default-jre` if using debian but will vary depending on your OS)
+* [Graphviz](https://graphviz.org/download/) installed
+
+#### With Anaconda (Recommended)
+
 Before proceeding with the manual installation, ensure you have the following prerequisites:
 
 * [Anaconda](https://conda.io/projects/conda/en/latest/index.html) installed and managing the Python installation
-* Python version 3.11.8 or lower
-* Java runtime environment (can be installed via `apt install default-jre`)
-* [Graphviz](https://graphviz.org/download/) installed
 
 To install the project manually:
 
@@ -133,6 +145,43 @@ To install the project manually:
 ```bash
 conda install -c conda-forge cvxopt
 conda install -c conda-forge pygraphviz
+./scripts/install_repositories.sh
+python3.11 -m pip install -r requirements.txt
+```
+
+#### Without Anaconda
+
+If you don't have Anaconda installed, you can still install the project manually on both linux distributions and MacOS.
+
+##### Linux
+Before proceeding, ensure you have the following prerequisites that are required (since there is no build wheel for cvxopt1.3.2 for linux):
+
+* lapack and blas libraries installed (can be installed via `apt install liblapack-dev libblas-dev` if using debian but will vary depending on your OS)
+* suiteparse library installed (can be installed via `apt install libsuitesparse-dev` if using debian but will vary depending on your OS)
+* glpk library installed (can be installed via `apt install libglpk-dev` if using debian but will vary depending on your OS)
+
+To install the project manually:
+
+1. Set up a Python virtual environment (recommended)
+2. Navigate to the project root directory
+3. Run the following commands:
+
+```bash
+./scripts/install_repositories.sh
+export CPPFLAGS="-I/usr/include/suitesparse"
+export CVXOPT_BUILD_GLPK=1
+python3.11 -m pip install -r requirements.txt
+```
+
+##### MacOS
+
+To install the project manually on MacOS:
+
+1. Set up a Python virtual environment (recommended)
+2. Navigate to the project root directory
+3. Run the following commands:
+
+```bash
 ./scripts/install_repositories.sh
 python3.11 -m pip install -r requirements.txt
 ```


### PR DESCRIPTION
Explores how to install via pip instead of using anaconda. 

- Macos works fine as there is an up to date wheel for cvxopt1.3.2
- linux needs pre-requisites and some flags set for pip install

Updated:

- devcontainer to use linux
- github workflow to test all supported installations
- README updated to account for install options