### PR TITLE
Add tests processing headers json data converter

### DIFF
--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -750,10 +750,16 @@ def _navigate_list(
     :return: The value at index 0 of the list
     :rtype: `dict`[`str`, `Any`]
     """
-    try:
-        return data[0]
-    except IndexError:
+    if not data:
         raise IndexError("Cannot return a value for an empty list.")
+    
+    if len(data) > 1:
+        raise ValueError(
+            "Code is structured to process lists that have one item. "
+            f"Got {len(data)} items instead."
+        )
+    
+    return data[0]
 
 
 def _update_header_dict(

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -647,9 +647,7 @@ def _extract_value_from_path(
         return _extract_simple_value(data, path)
 
 
-def _extract_nested_value(
-    data: dict[str, Any], path: str
-) -> dict[str, Any]:
+def _extract_nested_value(data: dict[str, Any], path: str) -> dict[str, Any]:
     """Extract a nested value from JSON data using a complex path.
 
     :param data: The JSON data to traverse

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -752,13 +752,13 @@ def _navigate_list(
     """
     if not data:
         raise IndexError("Cannot return a value for an empty list.")
-    
+
     if len(data) > 1:
         raise ValueError(
             "Code is structured to process lists that have one item. "
             f"Got {len(data)} items instead."
         )
-    
+
     return data[0]
 
 

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -715,8 +715,8 @@ def _navigate_dict(
             return data_to_return
         else:
             raise TypeError(
-                "Value should be of type dict, list or str - got"
-                f" {type(data[segment])} instead."
+                "Error navigating header - value should be of type dict,"
+                f" list or str - got {type(data[segment])} instead."
             )
     except KeyError:
         raise KeyError(f"{segment} is not a valid key.")
@@ -725,11 +725,11 @@ def _navigate_dict(
 def _navigate_list(
     data: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    """Navigate through a dictionary of the JSON data.
+    """Navigate through a list of the JSON data.
 
     :param data: The current data object
     :type data: `list`[`dict`[`str`, `Any`]]
-    :return: The value at the end of the navigation
+    :return: The value at index 0 of the list
     :rtype: `dict`[`str`, `Any`]
     """
     try:

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -744,7 +744,7 @@ def _update_header_dict(
     value: dict[str, Any] | str | list[dict[str, Any]],
 ) -> None:
     """Updates the header dictionary with the extracted value. If the value is
-    a dictionary, flatten it first.
+    a dictionary or list, flatten it first.
 
     :param header_dict: The header dictionary to update
     :type header_dict: `dict`[`str`, `Any`]

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -693,23 +693,39 @@ def _extract_simple_value(
 
 
 def _navigate_segment(
-    data: dict[str, Any] | str, segment: str
+    data: dict[str, Any] | str | list[dict[str, Any]], segment: str
 ) -> dict[str, Any] | str:
     """Navigate through a segment of the JSON data.
 
     :param data: The current data object
-    :type data: `dict`[`str`, `Any`]
+    :type data: `dict`[`str`, `Any`] | `str` | `list`[`dict`[`str`, `Any`]]
     :param segment: The segment to navigate
     :type segment: `str`
     :return: The value at the end of the navigation
     :rtype: `dict`[`str`, `Any`] | `str`
     """
-    if isinstance(data, dict):
-        data = data[segment]
-    elif isinstance(data, list):
-        data = data[0]
 
-    return data
+    if isinstance(data, str):
+        return data
+    elif isinstance(data, list):
+        if not data:
+            raise IndexError("Unable to access data within an empty list.")
+        data = data[0]
+    elif isinstance(data, dict):
+        try:
+            data = data[segment]
+        except KeyError:
+            raise KeyError(
+                f"'{segment}' is an invalid key for the given dictionary."
+            )
+
+    if isinstance(data, dict) or isinstance(data, str):
+        return data
+    else:
+        raise TypeError(
+            "Data should be of type 'dict', 'list', or 'str',"
+            f" got '{type(data)}' instead."
+        )
 
 
 def _update_header_dict(

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -12,16 +12,16 @@ MAX_SEGMENT_COUNT = 50  # TODO have a think about this
 
 
 def _flatten_json_dict(
-    json_data: dict[str, Any] | list[dict[str, Any]],
+    data: dict[str, Any] | list[dict[str, Any]],
 ) -> flatdict.FlatterDict:
-    """Function to flatten a nested dictionary.
+    """Function to flatten a dictionary or list.
 
-    :param json_data: The JSON data to flatten.
-    :param json_data: `dict`[`str`,`Any`] | `list`[`dict`[`str`, `Any`]]
+    :param data: The JSON data to flatten.
+    :param data: `dict`[`str`,`Any`] | `list`[`dict`[`str`, `Any`]]
     :return: The flattened json as a dictionary
     :rtype: :class: `flatdict.FlatterDict`
     """
-    return flatdict.FlatterDict(json_data)
+    return flatdict.FlatterDict(data)
 
 
 def _map_data_to_json_schema(
@@ -655,7 +655,7 @@ def _extract_nested_value(data: dict[str, Any], path: str) -> dict[str, Any]:
     :param path: The complex path string
     :type path: `str`
     :return: A nested dictionary with the extracted value
-    :rtype: `dict`[`str`, `Any`] | `str`
+    :rtype: `dict`[`str`, `Any`]
     """
     path_segments = path.split(":")
     parsed_data: dict[str, Any] | str | list[dict[str, Any]] = data

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -649,7 +649,7 @@ def _extract_value_from_path(
 
 def _extract_nested_value(
     data: dict[str, Any], path: str
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Extract a nested value from JSON data using a complex path.
 
     :param data: The JSON data to traverse
@@ -668,12 +668,32 @@ def _extract_nested_value(
             parsed_data = _navigate_list(parsed_data)
 
     path_segments = ":".join(path_segments).split("::")
-    # Create a nested dictionary by building it from the inside out. This is
-    # bypassed if data is a string
-    for key in reversed(path_segments[1:]):
-        result = {key: parsed_data}
 
-    return result
+    return _build_nested_dict(path_segments, parsed_data)
+
+
+def _build_nested_dict(
+    path_segments: list[str],
+    parsed_data: dict[str, Any] | str | list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Generates a nested dictionary by building it from the inside out.
+
+    :param path_segments: The segments within the path, split by ::
+    :type path_segments: `list`[`str`]
+    :param parsed_data: The parsed data within the json
+    :type parsed_data: `dict`[`str`, `Any`] | `str` |
+    `list`[`dict`[`str`, `Any`]]
+    :return: The nested dictionary
+    :rtype: `dict`[`str`, `Any`]
+    """
+    result = parsed_data
+    for key in reversed(path_segments[1:]):
+        result = {key: result}
+
+    if isinstance(result, dict):
+        return result
+    else:
+        raise TypeError(f"Expected type dict, got {type(result)} instead.")
 
 
 def _extract_simple_value(

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -67,9 +67,9 @@ class TestProcessHeaders:
         assert _navigate_list(data2) == expected2
 
         # Test with an empty list
-        data = []
+        data3: list[dict[str, Any]] = []
         with pytest.raises(IndexError):
-            _navigate_list(data)
+            _navigate_list(data3)
 
     @staticmethod
     def test_extract_simple_value() -> None:

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -143,7 +143,7 @@ class TestProcessHeaders:
         path1 = "key1:key2"
         value1 = {"key3": "value"}
         _update_header_dict(header_dict, path1, value1)
-        assert header_dict[path1]
+        assert len(header_dict) == 1
         assert header_dict[path1] == flatdict.FlatterDict(value1)
 
         # Test updating with a dict complex path
@@ -151,6 +151,7 @@ class TestProcessHeaders:
         path2 = "key1::key2"
         value2 = {"key3": "value"}
         _update_header_dict(header_dict, path2, value2)
+        assert len(header_dict) == 1
         assert header_dict["key1"] == flatdict.FlatterDict(value2)
 
         # Test updating with a list simple path
@@ -158,7 +159,7 @@ class TestProcessHeaders:
         path3 = "key1:key2"
         value3 = [{"key3": "value"}]
         _update_header_dict(header_dict, path3, value3)
-        assert header_dict[path3]
+        assert len(header_dict) == 1
         assert header_dict[path3] == flatdict.FlatterDict(value3)
 
         # Test updating with a list complex path
@@ -166,6 +167,7 @@ class TestProcessHeaders:
         path4 = "key1::key2"
         value4 = [{"key3": "value"}]
         _update_header_dict(header_dict, path4, value4)
+        assert len(header_dict) == 1
         assert header_dict["key1"] == flatdict.FlatterDict(value4)
 
         # Test updating with a string simple path
@@ -173,6 +175,7 @@ class TestProcessHeaders:
         path5 = "key1:key2"
         value5 = "value"
         _update_header_dict(header_dict, path5, value5)
+        assert len(header_dict) == 1
         assert header_dict[path5] == "value"
 
         # Test updating with a string complex path
@@ -180,6 +183,7 @@ class TestProcessHeaders:
         path6 = "key1::key2"
         value6 = "value"
         _update_header_dict(header_dict, path6, value6)
+        assert len(header_dict) == 1
         assert header_dict["key1"] == "value"
 
     @staticmethod

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -71,6 +71,11 @@ class TestProcessHeaders:
         with pytest.raises(IndexError):
             _navigate_list(data3)
 
+        # Test list with more than one element
+        data4 = [{"key1": "value1"}, {"key2": "value2"}]
+        with pytest.raises(ValueError):
+            _navigate_list(data4)
+
     @staticmethod
     def test_extract_simple_value() -> None:
         """Tests the function _extract_simple_value."""

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -12,7 +12,7 @@ from tel2puml.find_unique_graphs.otel_ingestion.json_data_converter import (
     _extract_value_from_path,
     _extract_simple_value,
     _update_header_dict,
-    _extract_nested_value,
+    _build_nested_dict,
 )
 
 
@@ -150,3 +150,13 @@ class TestProcessHeaders:
         value6 = "value"
         _update_header_dict(header_dict, path6, value6)
         assert header_dict["key1"] == "value"
+
+    @staticmethod
+    def test_build_nested_dict() -> None:
+        """Tests the function _build_nested_dict"""
+
+        path_segments = ["segment1", "segment2", "segment3"]
+        parsed_data = "data"
+        assert _build_nested_dict(path_segments, parsed_data) == {
+            "segment2": {"segment3": "data"}
+        }

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -207,7 +207,7 @@ class TestProcessHeaders:
         expected2 = {"key2": {"key3": "string_value"}}
         assert _build_nested_dict(path_segments2, parsed_data2) == expected2
 
-        # Test with list of dicts3
+        # Test with list of dicts
         path_segments3 = ["key1", "key2", "key3"]
         parsed_data3 = [{"key4": "value4"}, {"key5": "value5"}]
         expected3 = {
@@ -218,9 +218,7 @@ class TestProcessHeaders:
         # Test error handling with one path segment. In reality there will
         # always be more than one path segment since the path requires '::'
         # for the function to be reached
-        path_segments4 = ["key1"]
-        parsed_data4 = 123
+        path_segments4 = ["key"]
+        parsed_data4 = "string_value"
         with pytest.raises(TypeError):
-            _build_nested_dict(
-                path_segments4, parsed_data4  # type: ignore[arg-type]
-            )
+            _build_nested_dict(path_segments4, parsed_data4)

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -1,6 +1,7 @@
 """Tests for json data converter module."""
 
 import pytest
+import unittest.mock
 
 from tel2puml.find_unique_graphs.otel_ingestion.json_data_converter import (
     _navigate_dict,
@@ -66,3 +67,35 @@ class TestProcessHeaders:
             {"id": 1, "name": "item1"},
             {"id": 2, "name": "item2"},
         ]
+
+    @staticmethod
+    def test_extract_value_from_path() -> None:
+        """Tests the function _extract_value_from_path"""
+
+        with unittest.mock.patch(
+            "tel2puml.find_unique_graphs.otel_ingestion.json_data_converter._extract_simple_value"
+        ) as extract_simple_value, unittest.mock.patch(
+            "tel2puml.find_unique_graphs.otel_ingestion.json_data_converter._extract_nested_value"
+        ) as extract_nested_value:
+            # Test simple path
+            data = {"key1": {"key2": "value"}}
+            path = "key1:key2"
+            _extract_value_from_path(data, path)
+            extract_simple_value.assert_called_once()
+            extract_nested_value.assert_not_called()
+
+            # Reset the mocks
+            extract_simple_value.reset_mock()
+            extract_nested_value.reset_mock()
+
+            # Test complex path
+            data = {
+                "key1": [
+                    {"id": 1, "name": "item1"},
+                    {"id": 2, "name": "item2"},
+                ]
+            }
+            path = "key1::id"
+            _extract_value_from_path(data, path)
+            extract_simple_value.assert_not_called()
+            extract_nested_value.assert_called_once()

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -23,13 +23,13 @@ class TestProcessHeaders:
     def test_navigate_dict() -> None:
         """Tests the function _navigate_segment"""
 
-        data1 = {"key1": {"key2": "value"}}
+        data = {"key1": {"key2": "value"}}
         segment = "key1"
-        assert _navigate_dict(data1, segment) == {"key2": "value"}
+        assert _navigate_dict(data, segment) == {"key2": "value"}
         # Test with an invalid key
         invalid_segment = "invalid"
         with pytest.raises(KeyError):
-            _navigate_dict(data1, invalid_segment)
+            _navigate_dict(data, invalid_segment)
 
     @staticmethod
     def test_navigate_list() -> None:
@@ -92,14 +92,14 @@ class TestProcessHeaders:
             extract_nested_value.reset_mock()
 
             # Test complex path
-            data = {
+            data2 = {
                 "key1": [
                     {"id": 1, "name": "item1"},
                     {"id": 2, "name": "item2"},
                 ]
             }
             path = "key1::id"
-            _extract_value_from_path(data, path)
+            _extract_value_from_path(data2, path)
             extract_simple_value.assert_not_called()
             extract_nested_value.assert_called_once()
 
@@ -109,48 +109,44 @@ class TestProcessHeaders:
 
         # Test updating with a dict simple path
         header_dict: dict[str, Any] = {}
-        path = "key1:key2"
-        value = {"key3": "value"}
-        _update_header_dict(header_dict, path, value)
-        assert header_dict[path]
-        assert header_dict[path] == flatdict.FlatterDict(value)
+        path1 = "key1:key2"
+        value1 = {"key3": "value"}
+        _update_header_dict(header_dict, path1, value1)
+        assert header_dict[path1]
+        assert header_dict[path1] == flatdict.FlatterDict(value1)
 
         # Test updating with a dict complex path
-        header_dict: dict[str, Any] = {}
-        path = "key1::key2"
-        value = {"key3": "value"}
-        _update_header_dict(header_dict, path, value)
-        assert header_dict["key1"]
-        assert header_dict["key1"] == flatdict.FlatterDict(value)
+        header_dict = {}
+        path2 = "key1::key2"
+        value2 = {"key3": "value"}
+        _update_header_dict(header_dict, path2, value2)
+        assert header_dict["key1"] == flatdict.FlatterDict(value2)
 
         # Test updating with a list simple path
-        header_dict: dict[str, Any] = {}
-        path = "key1:key2"
-        value = [{"key3": "value"}]
-        _update_header_dict(header_dict, path, value)
-        assert header_dict[path]
-        assert header_dict[path] == flatdict.FlatterDict(value)
+        header_dict = {}
+        path3 = "key1:key2"
+        value3 = [{"key3": "value"}]
+        _update_header_dict(header_dict, path3, value3)
+        assert header_dict[path3]
+        assert header_dict[path3] == flatdict.FlatterDict(value3)
 
         # Test updating with a list complex path
-        header_dict: dict[str, Any] = {}
-        path = "key1::key2"
-        value = [{"key3": "value"}]
-        _update_header_dict(header_dict, path, value)
-        assert header_dict["key1"]
-        assert header_dict["key1"] == flatdict.FlatterDict(value)
+        header_dict = {}
+        path4 = "key1::key2"
+        value4 = [{"key3": "value"}]
+        _update_header_dict(header_dict, path4, value4)
+        assert header_dict["key1"] == flatdict.FlatterDict(value4)
 
         # Test updating with a string simple path
-        header_dict: dict[str, Any] = {}
-        path = "key1:key2"
-        value = "value"
-        _update_header_dict(header_dict, path, value)
-        assert header_dict[path]
-        assert header_dict[path] == "value"
+        header_dict = {}
+        path5 = "key1:key2"
+        value5 = "value"
+        _update_header_dict(header_dict, path5, value5)
+        assert header_dict[path5] == "value"
 
         # Test updating with a string complex path
-        header_dict: dict[str, Any] = {}
-        path = "key1::key2"
-        value = "value"
-        _update_header_dict(header_dict, path, value)
-        assert header_dict["key1"]
+        header_dict = {}
+        path6 = "key1::key2"
+        value6 = "value"
+        _update_header_dict(header_dict, path6, value6)
         assert header_dict["key1"] == "value"

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -2,6 +2,9 @@
 
 import pytest
 import unittest.mock
+import flatdict
+
+from typing import Any
 
 from tel2puml.find_unique_graphs.otel_ingestion.json_data_converter import (
     _navigate_dict,
@@ -99,3 +102,55 @@ class TestProcessHeaders:
             _extract_value_from_path(data, path)
             extract_simple_value.assert_not_called()
             extract_nested_value.assert_called_once()
+
+    @staticmethod
+    def test_update_header_dict() -> None:
+        """Tests the function _update_header_dict"""
+
+        # Test updating with a dict simple path
+        header_dict: dict[str, Any] = {}
+        path = "key1:key2"
+        value = {"key3": "value"}
+        _update_header_dict(header_dict, path, value)
+        assert header_dict[path]
+        assert header_dict[path] == flatdict.FlatterDict(value)
+
+        # Test updating with a dict complex path
+        header_dict: dict[str, Any] = {}
+        path = "key1::key2"
+        value = {"key3": "value"}
+        _update_header_dict(header_dict, path, value)
+        assert header_dict["key1"]
+        assert header_dict["key1"] == flatdict.FlatterDict(value)
+
+        # Test updating with a list simple path
+        header_dict: dict[str, Any] = {}
+        path = "key1:key2"
+        value = [{"key3": "value"}]
+        _update_header_dict(header_dict, path, value)
+        assert header_dict[path]
+        assert header_dict[path] == flatdict.FlatterDict(value)
+
+        # Test updating with a list complex path
+        header_dict: dict[str, Any] = {}
+        path = "key1::key2"
+        value = [{"key3": "value"}]
+        _update_header_dict(header_dict, path, value)
+        assert header_dict["key1"]
+        assert header_dict["key1"] == flatdict.FlatterDict(value)
+
+        # Test updating with a string simple path
+        header_dict: dict[str, Any] = {}
+        path = "key1:key2"
+        value = "value"
+        _update_header_dict(header_dict, path, value)
+        assert header_dict[path]
+        assert header_dict[path] == "value"
+
+        # Test updating with a string complex path
+        header_dict: dict[str, Any] = {}
+        path = "key1::key2"
+        value = "value"
+        _update_header_dict(header_dict, path, value)
+        assert header_dict["key1"]
+        assert header_dict["key1"] == "value"

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -23,20 +23,49 @@ class TestProcessHeaders:
     def test_navigate_dict() -> None:
         """Tests the function _navigate_segment"""
 
-        data = {"key1": {"key2": "value"}}
-        segment = "key1"
-        assert _navigate_dict(data, segment) == {"key2": "value"}
+        # Test valid dict
+        data1 = {"key1": {"key2": "value2"}}
+        segment1 = "key1"
+        expected1 = {"key2": "value2"}
+        assert _navigate_dict(data1, segment1) == expected1
+
+        # Test valid string
+        data2 = {"key1": "value1"}
+        segment2 = "key1"
+        expected2 = "value1"
+        assert _navigate_dict(data2, segment2) == expected2
+
+        # Test valid list
+        data3 = {"key1": [{"key2": "value2"}, {"key3": "value3"}]}
+        segment3 = "key1"
+        expected3 = [{"key2": "value2"}, {"key3": "value3"}]
+        assert _navigate_dict(data3, segment3) == expected3
+
         # Test with an invalid key
-        invalid_segment = "invalid"
+        data4 = {"key1": "value1"}
+        segment4 = "invalid"
         with pytest.raises(KeyError):
-            _navigate_dict(data, invalid_segment)
+            _navigate_dict(data4, segment4)
+
+        # Test invalid type
+        data5 = {"key1": 123}  # Not a dict, list, or str
+        segment5 = "key1"
+        with pytest.raises(TypeError):
+            _navigate_dict(data5, segment5)
 
     @staticmethod
     def test_navigate_list() -> None:
         """Tests the function _navigate_segment"""
 
-        data = [{"key1": {"key2": "value"}}]
-        assert _navigate_list(data) == {"key1": {"key2": "value"}}
+        # Test non empty list
+        data1 = [{"key1": {"key2": "value"}}]
+        assert _navigate_list(data1) == {"key1": {"key2": "value"}}
+
+        # Test list with single element
+        data2 = [{"key1": "value1"}]
+        expected2 = {"key1": "value1"}
+        assert _navigate_list(data2) == expected2
+
         # Test with an empty list
         data = []
         with pytest.raises(IndexError):

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -21,7 +21,7 @@ class TestProcessHeaders:
 
     @staticmethod
     def test_navigate_dict() -> None:
-        """Tests the function _navigate_segment"""
+        """Tests the function _navigate_dict"""
 
         # Test valid dict
         data1 = {"key1": {"key2": "value2"}}
@@ -55,7 +55,7 @@ class TestProcessHeaders:
 
     @staticmethod
     def test_navigate_list() -> None:
-        """Tests the function _navigate_segment"""
+        """Tests the function _navigate_list"""
 
         # Test non empty list
         data1 = [{"key1": {"key2": "value"}}]

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -1,0 +1,48 @@
+"""Tests for json data converter module."""
+
+import pytest
+
+from tel2puml.find_unique_graphs.otel_ingestion.json_data_converter import (
+    _navigate_segment,
+    _extract_value_from_path,
+    _extract_simple_value,
+    _update_header_dict,
+    _extract_nested_value,
+)
+
+
+class TestProcessHeaders:
+    """Tests for processing headers within json data converter module."""
+
+    @staticmethod
+    def test_navigate_segment() -> None:
+        """Tests the function _navigate_segment"""
+
+        # Test when data is a dict
+        data1 = {"key1": {"key2": "value"}}
+        segment = "key1"
+        assert _navigate_segment(data1, segment) == {"key2": "value"}
+        # Test with an invalid key
+        invalid_segment = "invalid"
+        with pytest.raises(KeyError):
+            _navigate_segment(data1, invalid_segment)
+
+        # Test when data is a list
+        data2 = [{"key1": {"key2": "value"}}]
+        segment = "key1"
+        assert _navigate_segment(data2, segment) == {"key1": {"key2": "value"}}
+        # Test with an empty list
+        data2 = []
+        with pytest.raises(IndexError):
+            _navigate_segment(data2, segment)
+
+        # Test when data is a string
+        data3 = "value"
+        segment = "key"
+        assert _navigate_segment(data3, segment) == "value"
+
+        # Test when data is not type dict, list, or str
+        data4 = 10
+        segment = "key"
+        with pytest.raises(TypeError):
+            _navigate_segment(data4, segment)  # type: ignore[arg-type]

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -157,8 +157,32 @@ class TestProcessHeaders:
     def test_build_nested_dict() -> None:
         """Tests the function _build_nested_dict"""
 
-        path_segments = ["segment1", "segment2", "segment3"]
-        parsed_data = "data"
-        assert _build_nested_dict(path_segments, parsed_data) == {
-            "segment2": {"segment3": "data"}
+        # Test multiple segments
+        path_segments1 = ["key1", "key2", "key3"]
+        parsed_data1 = {"key4": "value4"}
+        expected1 = {"key2": {"key3": {"key4": "value4"}}}
+        assert _build_nested_dict(path_segments1, parsed_data1) == expected1
+
+        # Test with string data
+        path_segments2 = ["key1", "key2", "key3"]
+        parsed_data2 = "string_value"
+        expected2 = {"key2": {"key3": "string_value"}}
+        assert _build_nested_dict(path_segments2, parsed_data2) == expected2
+
+        # Test with list of dicts3
+        path_segments3 = ["key1", "key2", "key3"]
+        parsed_data3 = [{"key4": "value4"}, {"key5": "value5"}]
+        expected3 = {
+            "key2": {"key3": [{"key4": "value4"}, {"key5": "value5"}]}
         }
+        assert _build_nested_dict(path_segments3, parsed_data3) == expected3
+
+        # Test error handling with one path segment. In reality there will
+        # always be more than one path segment since the path requires '::'
+        # for the function to be reached
+        path_segments4 = ["key1"]
+        parsed_data4 = 123
+        with pytest.raises(TypeError):
+            _build_nested_dict(
+                path_segments4, parsed_data4  # type: ignore[arg-type]
+            )

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -3,7 +3,8 @@
 import pytest
 
 from tel2puml.find_unique_graphs.otel_ingestion.json_data_converter import (
-    _navigate_segment,
+    _navigate_dict,
+    _navigate_list,
     _extract_value_from_path,
     _extract_simple_value,
     _update_header_dict,
@@ -15,34 +16,53 @@ class TestProcessHeaders:
     """Tests for processing headers within json data converter module."""
 
     @staticmethod
-    def test_navigate_segment() -> None:
+    def test_navigate_dict() -> None:
         """Tests the function _navigate_segment"""
 
-        # Test when data is a dict
         data1 = {"key1": {"key2": "value"}}
         segment = "key1"
-        assert _navigate_segment(data1, segment) == {"key2": "value"}
+        assert _navigate_dict(data1, segment) == {"key2": "value"}
         # Test with an invalid key
         invalid_segment = "invalid"
         with pytest.raises(KeyError):
-            _navigate_segment(data1, invalid_segment)
+            _navigate_dict(data1, invalid_segment)
 
-        # Test when data is a list
-        data2 = [{"key1": {"key2": "value"}}]
-        segment = "key1"
-        assert _navigate_segment(data2, segment) == {"key1": {"key2": "value"}}
+    @staticmethod
+    def test_navigate_list() -> None:
+        """Tests the function _navigate_segment"""
+
+        data = [{"key1": {"key2": "value"}}]
+        assert _navigate_list(data) == {"key1": {"key2": "value"}}
         # Test with an empty list
-        data2 = []
+        data = []
         with pytest.raises(IndexError):
-            _navigate_segment(data2, segment)
+            _navigate_list(data)
 
-        # Test when data is a string
-        data3 = "value"
-        segment = "key"
-        assert _navigate_segment(data3, segment) == "value"
+    @staticmethod
+    def test_extract_simple_value() -> None:
+        """Tests the function _extract_simple_value."""
 
-        # Test when data is not type dict, list, or str
-        data4 = 10
-        segment = "key"
-        with pytest.raises(TypeError):
-            _navigate_segment(data4, segment)  # type: ignore[arg-type]
+        # Test returning a string value
+        data = {"key1": {"key2": "value"}}
+        path = "key1:key2"
+        assert _extract_simple_value(data, path) == "value"
+
+        # Test returning a dict
+        data = {"key1": {"key2": "value"}}
+        path = "key1"
+        assert _extract_simple_value(data, path) == {"key2": "value"}
+
+        # Test returning a list
+        data2 = {
+            "key1": {
+                "key2": [
+                    {"id": 1, "name": "item1"},
+                    {"id": 2, "name": "item2"},
+                ]
+            }
+        }
+        path = "key1:key2"
+        assert _extract_simple_value(data2, path) == [
+            {"id": 1, "name": "item1"},
+            {"id": 2, "name": "item2"},
+        ]

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -76,9 +76,11 @@ class TestProcessHeaders:
         """Tests the function _extract_value_from_path"""
 
         with unittest.mock.patch(
-            "tel2puml.find_unique_graphs.otel_ingestion.json_data_converter._extract_simple_value"
+            "tel2puml.find_unique_graphs.otel_ingestion."
+            "json_data_converter._extract_simple_value"
         ) as extract_simple_value, unittest.mock.patch(
-            "tel2puml.find_unique_graphs.otel_ingestion.json_data_converter._extract_nested_value"
+            "tel2puml.find_unique_graphs.otel_ingestion."
+            "json_data_converter._extract_nested_value"
         ) as extract_nested_value:
             # Test simple path
             data = {"key1": {"key2": "value"}}


### PR DESCRIPTION
This PR updates json_data_converter:
- Updated type hints
- Split navigate_segment function into navigate_list and navigate_dict.
- Add build_nested_dict function to extract_nested_value function.

Tests have been written for the following functions:

- navigate_dict
- navigate_list
- extract_simple_value
- extract_value_from_path
- update_header_dict
- build_nested_dict