### PR TITLE
Add tests for process header and extract nested values

### DIFF
--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -282,6 +282,7 @@ class TestProcessHeaders:
 
         header_dict: dict[str, Any] = process_header(json_config, mock_data)
 
+        assert len(header_dict) == 2
         assert header_dict["resource:attributes"] == flatdict.FlatterDict(
             [
                 {
@@ -294,7 +295,6 @@ class TestProcessHeaders:
                 },
             ]
         )
-
         assert header_dict["scope_spans"] == flatdict.FlatterDict(
             {"scope": {"name": "TestJob"}}
         )


### PR DESCRIPTION
This PR adds tests to the following functions to handle processing headers within json data converter:

- process_header
- extract_nested_value