### PR TITLE
82-tests-for-handling-data-from-header-tags

### DIFF
--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -550,7 +550,10 @@ def _get_value_type(field_config: dict[str, str]) -> str:
     :return: The field type
     :rtype: `str`
     """
-    return field_config["value_type"]
+    try:
+        return field_config["value_type"]
+    except KeyError:
+        raise KeyError("Field config must include a 'value_type' section.")
 
 
 def _add_or_append_value(

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -572,12 +572,15 @@ def _add_or_append_value(
     :param value_type: The field type
     :type value_type: `str`
     """
+    if not value_type in ["unix_nano", "string"]:
+        raise ValueError("Unrecognised value_type")
+
     if value_type == "unix_nano":
         if not isinstance(value, int):
             raise TypeError(
                 f"Datetime should be of type 'int', got '{type(value)}'."
             )
-    else:
+    elif value:
         if not isinstance(value, str):
             value = str(value)
 

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -29,7 +29,7 @@ def _flatten_json_dict(
 
 def _map_data_to_json_schema(
     json_config: JSONDataSourceConfig,
-    flattened_data: Any,
+    flattened_data: flatdict.FlatterDict,
     config_key: Literal["field_mapping"],
     header_dict: dict[str, Any],
 ) -> dict[str, Any]:
@@ -40,7 +40,7 @@ def _map_data_to_json_schema(
     :param json_config: The mapping config pulled from the yaml config file
     :type json_config: :class:`JSONDataSourceConfig`
     :param flattened_data: JSON data as a flattened dictionary
-    :type flattened_data: `Any`
+    :type flattened_data: :class:`flatdict.FlatterDict`
     :param config_key: The key for the json config fields
     :type config_key: `Literal`["field_mapping"]
     :param header_dict: A dictionary of flattened json data containing header
@@ -68,7 +68,7 @@ def _map_data_to_json_schema(
 def _process_field(
     field_name: str,
     field_config: FieldSpec,
-    flattened_data: Any,
+    flattened_data: flatdict.FlatterDict,
     result: dict[str, Any],
     field_cache: dict[str, str],
     header_dict: dict[str, Any],
@@ -81,7 +81,7 @@ def _process_field(
     :param field_config: The config for the field name
     :type field_config: :class: `FieldSpec`
     :param flattened_data: JSON data as a flattened dictionary
-    :type flattened_data: `Any`
+    :type flattened_data: :class:`flatdict.FlatterDict`
     :param result: The mapped data
     :type result: `dict`[`str`, `Any`]
     :param field_cache: Cache for optimising field access and path generation
@@ -121,7 +121,7 @@ def _process_field(
 def _handle_empty_segments(
     field_name: str,
     field_config: FieldSpec,
-    flattened_data: Any,
+    flattened_data: flatdict.FlatterDict,
     index: int,
     result: dict[str, Any],
     field_cache: dict[str, str],
@@ -137,7 +137,7 @@ def _handle_empty_segments(
     :param field_config: The config for the field name
     :type field_config: `dict`[`str`,`Any`]
     :param flattened_data: JSON data as a flattened dictionary
-    :type flattened_data: `Any`
+    :type flattened_data: :class:`flatdict.FlatterDict`
     :param index: The index of the field config
     :type index: `int`
     :param result: The mapped data
@@ -425,14 +425,14 @@ def _get_cached_path(
 
 
 def _is_matching_data(
-    flattened_data: dict[str, str], full_path: str, value_to_check: str
+    flattened_data: flatdict.FlatterDict, full_path: str, value_to_check: str
 ) -> bool:
     """
     Function that checks if the data at the given path in flattened_data
     matches the value_to_check.
 
     :param flattened_data: The flattened JSON data to check
-    :type flattened_data: `dict`[`str`, `str`]
+    :type flattened_data: :class: `flatdict.FlatterDict`
     :param full_path: The path to check in the flattened data
     :type full_path: `str`
     :param value_to_check: The value to compare against the data at full_path
@@ -450,7 +450,7 @@ def _process_matching_data(
     field_name: str,
     field_config: FieldSpec,
     index: int,
-    flattened_data: dict[str, Any],
+    flattened_data: flatdict.FlatterDict,
     full_path: str,
     key: str,
     result: dict[str, Any],
@@ -465,7 +465,7 @@ def _process_matching_data(
     :param index: The index of the field config
     :type index: `int`
     :param flattened_data: JSON data as a flattened dictionary
-    :type flattened_data: `Any`
+    :type flattened_data: :class: `flatdict.FlatterDict`
     :param full_path: The original path containing placeholders
     :type full_path: `str`
     :param key: The key within the full path to replace
@@ -482,7 +482,7 @@ def _process_matching_data(
 
 def _update_cache(
     cache_entry: dict[str, Any],
-    flattened_data: dict[str, str],
+    flattened_data: flatdict.FlatterDict,
     full_path: str,
 ) -> None:
     """Function to update the cache.
@@ -490,7 +490,7 @@ def _update_cache(
     :param cache_entry: The current entry within the cache
     :type cache_entry: `dict`[str, `Any`]
     :param flattened_data: JSON data as a flattened dictionary
-    :type flattened_data: `Any`
+    :type flattened_data: :class:`flatdict.FlatterDict`
     :param full_path: The path to update within the cache
     :type full_path: `str`
     """
@@ -502,7 +502,7 @@ def _handle_regular_path(
     field_name: str,
     field_config: FieldSpec,
     full_path: str,
-    flattened_data: Any,
+    flattened_data: flatdict.FlatterDict,
     result: dict[str, Any],
     header_dict: dict[str, Any],
 ) -> None:
@@ -516,7 +516,7 @@ def _handle_regular_path(
     :param full_path: The key of the flattened data
     :type full_path: `str`
     :param flattened_data: JSON data as a flattened dictionary
-    :type flattened_data: `Any`
+    :type flattened_data: :class: `flatdict.FlatterDict`
     :param result: The mapped data
     :type result: `dict`[`str`, `Any`]
     :param header_dict: A dictionary of flattened json data containing header

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -854,7 +854,7 @@ def _get_key_value(field_spec: FieldSpec, index: int) -> str:
         key_value = key_values[index]
     except IndexError:
         raise IndexError(f"Index {index} is out of range for key_value.")
-    
+
     if not key_value:
         raise ValueError(f"key_value at index {index} should not return None.")
 

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -580,7 +580,7 @@ def _add_or_append_value(
             raise TypeError(
                 f"Datetime should be of type 'int', got '{type(value)}'."
             )
-    elif value:
+    else:
         if not isinstance(value, str):
             value = str(value)
 

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -332,7 +332,7 @@ def _find_matching_header_value(
             try:
                 return header_level[full_header_key]
             except KeyError:
-                raise KeyError(f"{full_header_key} is an invalid key.")
+                raise KeyError(f"{header_key} is an invalid key.")
 
     raise KeyError(f"No matching value found for key: {target_key}")
 

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -879,9 +879,9 @@ def _get_value_path(field_spec: FieldSpec, index: int) -> str:
     try:
         value_path = value_paths[index]
     except IndexError:
-        raise IndexError(f"Index {index} is out of range for value_paths")
+        raise IndexError(f"Index {index} is out of range for value_paths.")
 
     if not value_path:
-        raise ValueError(f"value_path at index {index} is empty or None")
+        raise ValueError(f"value_path at index {index} is empty or None.")
 
     return value_path

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -470,10 +470,9 @@ def _process_matching_data(
     """
     value_path = full_path.replace(key, _get_value_path(field_config, index))
     value_type = _get_value_type(field_config)
-    if value_type:
-        _add_or_append_value(
-            field_name, flattened_data[value_path], result, value_type
-        )
+    _add_or_append_value(
+        field_name, flattened_data[value_path], result, value_type
+    )
 
 
 def _update_cache(
@@ -561,10 +560,23 @@ def _get_value_type(field_config: FieldSpec) -> str:
     :return: The field type
     :rtype: `str`
     """
+    expected_value_types = ["unix_nano", "string"]
     try:
-        return field_config["value_type"]
+        value_type = field_config["value_type"]
     except KeyError:
         raise KeyError("Field config must include a 'value_type' section.")
+
+    if not isinstance(value_type, str):
+        raise TypeError(
+            f"value_type should be a string, got {type(value_type)} instead."
+        )
+
+    if value_type not in expected_value_types:
+        raise ValueError(
+            "Supported value types include "
+            f"'{','.join(expected_value_types)}', got {value_type} instead."
+        )
+    return value_type
 
 
 def _add_or_append_value(
@@ -583,9 +595,6 @@ def _add_or_append_value(
     :param value_type: The field type
     :type value_type: `str`
     """
-    if value_type not in ["unix_nano", "string"]:
-        raise ValueError("Unrecognised value_type")
-
     if value_type == "unix_nano":
         if not isinstance(value, int):
             raise TypeError(

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -176,11 +176,13 @@ def _handle_empty_segments(
             # check for case where key value is not specifed, indicating
             # that the path within key_paths is the full path and the value
             # at that path is what we want.
-            if not field_config.get("key_value") and flattened_data.get(
-                full_path
+            if (
+                not "key_value" in field_config
+                or not field_config["key_value"][index]
             ):
-                result[field_name] = flattened_data.get(full_path)
-                return
+                if flattened_data.get(full_path):
+                    result[field_name] = flattened_data.get(full_path)
+                    return
 
             # Check the cache to see if the value that we are looking for has
             # already been looped over and stored.
@@ -206,10 +208,10 @@ def _handle_empty_segments(
                 return
             _update_cache(cache_entry, flattened_data, full_path)
 
-        except (KeyError, TypeError, IndexError, ValueError):
+        except (KeyError, TypeError):
             # Keep a record of the count so that we don't have to iterate
             # through the tried keys again. We get KeyError and TypeErrors when
-            # we try accessing a key within the field config dictionary that 
+            # we try accessing a key within the field config dictionary that
             # doesn't exist.
             cache_entry["count"] += 1
         except Exception as e:
@@ -841,7 +843,7 @@ def _get_key_value(field_spec: FieldSpec, index: int) -> str:
     :param index: The index within the key_value list
     :type index: `int`
     :return: The value within the key_value list, or None
-    :rtype: `str`
+    :rtype: `str` | `None`
     """
     try:
         key_values = field_spec["key_value"]
@@ -851,10 +853,10 @@ def _get_key_value(field_spec: FieldSpec, index: int) -> str:
     try:
         key_value = key_values[index]
     except IndexError:
-        raise IndexError(f"Index {index} is out of range for key_value")
-
+        raise IndexError(f"Index {index} is out of range for key_value.")
+    
     if not key_value:
-        raise ValueError(f"key_value at index {index} is empty or None")
+        raise ValueError(f"key_value at index {index} should not return None.")
 
     return key_value
 

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -255,7 +255,7 @@ def _handle_data_from_header(
     # Remove the 'HEADER:' prefix from the full path
     clean_header_path = full_header_path.split("HEADER:", 1)[1]
 
-    if not "::" in clean_header_path:
+    if "::" not in clean_header_path:
         # Resolves simple case
         extracted_value = header_data[clean_header_path]
     else:

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -149,7 +149,7 @@ def _handle_empty_segments(
     data
     :type header_dict: `dict`[`str`, `Any`]
     """
-    full_path = ":".join(field_config["key_paths"][index].split(":"))
+    full_path = field_config["key_paths"][index]
     key = full_path.split("::")[-1]
 
     if full_path.split(":")[0] == "HEADER":
@@ -253,37 +253,42 @@ def _handle_data_from_header(
     # Remove the 'HEADER:' prefix from the full path
     clean_header_path = full_header_path.split("HEADER:", 1)[1]
 
-    # Split the remaining path into segments
-    path_segments = clean_header_path.split("::")
-
-    # The last segment is the key we're searching for in the header_data
-    target_key = path_segments[-1]
-
-    # Update the header key if a specific value needs to be matched
-    if (
-        field_config.get("key_value")
-        and field_config["key_value"][config_index]
-    ):
-        header_key = _get_value_path(field_config, config_index)
+    if not "::" in clean_header_path:
+        # Resolves simple case
+        extracted_value = header_data[clean_header_path]
     else:
-        header_key = initial_header_key
+        # If a list is involvd, split segments
+        path_segments = clean_header_path.split("::")
 
-    # Navigate through the nested structure of header_data
-    current_header_level = header_data
-    for segment in path_segments[:-1]:
-        current_header_level = current_header_level[segment]
+        # The last segment is the key we're searching for in the header_data
+        target_key = path_segments[-1]
 
-    # Extract the value from header_data
-    if header_key == target_key:
-        extracted_value = current_header_level[header_key]
-    else:
-        extracted_value = _find_matching_header_value(
-            current_header_level,
-            target_key,
-            field_config,
-            config_index,
-            header_key,
-        )
+        # Update the header key to the key within 'value_paths' if a specific
+        # 'key_value' needs to be matched
+        if (
+            field_config.get("key_value")
+            and field_config["key_value"][config_index]
+        ):
+            header_key = _get_value_path(field_config, config_index)
+        else:
+            header_key = initial_header_key
+
+        # Navigate through the nested structure of header_data
+        current_header_level = header_data
+        for segment in path_segments[:-1]:
+            current_header_level = current_header_level[segment]
+
+        # Extract the value from header_data
+        if header_key == target_key:
+            extracted_value = current_header_level[header_key]
+        else:
+            extracted_value = _find_matching_header_value(
+                current_header_level,
+                target_key,
+                field_config,
+                config_index,
+                header_key,
+            )
 
     # Get the value type from the field config
     value_type = _get_value_type(field_config)

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -291,7 +291,7 @@ def _handle_data_from_header(
 
 
 def _find_matching_header_value(
-    header_level: dict[str, str],
+    header_level: flatdict.FlatterDict,
     target_key: str,
     field_config: dict[str, Any],
     config_index: int,
@@ -301,7 +301,7 @@ def _find_matching_header_value(
     Find the matching header value based on the target key and configuration.
 
     :param header_level: The current level of the header dictionary
-    :type header_level: `dict`[`str`, `str`]
+    :type header_level: :class:`flatdict.FlatterDict`
     :param target_key: The key to search for in the header
     :type target_key: `str`
     :param field_config: The configuration for the field
@@ -313,6 +313,9 @@ def _find_matching_header_value(
     :return: The extracted value from the header
     :rtype: `str`
     """
+    if not header_level:
+        raise ValueError("No data within header dictionary.")
+
     for key, value in header_level.items():
         key_suffix = key.split(":", 1)[-1]
         if (
@@ -322,7 +325,10 @@ def _find_matching_header_value(
             key_prefix = key.split(":", 1)[0]
             full_header_key = f"{key_prefix}:{header_key}"
 
-            return header_level[full_header_key]
+            try:
+                return header_level[full_header_key]
+            except KeyError:
+                raise KeyError(f"{full_header_key} is an invalid key.")
 
     raise KeyError(f"No matching value found for key: {target_key}")
 

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -187,7 +187,6 @@ def _handle_empty_segments(
             # If the value is not found within the cache, we start looking at
             # the value of 'count' that is stored within the cache, as we have
             # already checked values up until count - 1.
-            # value_to_check = field_config["key_value"][index]
             value_to_check = _get_key_value(field_config, index)
             full_path = _get_cached_path(
                 cache_entry, value_to_check, full_path, segment_count
@@ -207,10 +206,11 @@ def _handle_empty_segments(
                 return
             _update_cache(cache_entry, flattened_data, full_path)
 
-        except (KeyError, TypeError):
+        except (KeyError, TypeError, IndexError, ValueError):
             # Keep a record of the count so that we don't have to iterate
             # through the tried keys again. We get KeyError and TypeErrors when
-            # we try accessing a key within the dictionary that doesn't exist.
+            # we try accessing a key within the field config dictionary that 
+            # doesn't exist.
             cache_entry["count"] += 1
         except Exception as e:
             print(f"An error occured - {e}")
@@ -466,7 +466,6 @@ def _process_matching_data(
     :param result: The mapped data
     :type result: `dict`[`str`, `Any`]
     """
-    # value_path = full_path.replace(key, field_config["value_paths"][index])
     value_path = full_path.replace(key, _get_value_path(field_config, index))
     value_type = _get_value_type(field_config)
     if value_type:

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -2,7 +2,7 @@
 
 import flatdict
 
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from tel2puml.find_unique_graphs.otel_ingestion.otel_data_model import (
     JSONDataSourceConfig,
@@ -177,7 +177,7 @@ def _handle_empty_segments(
             # that the path within key_paths is the full path and the value
             # at that path is what we want.
             if (
-                not "key_value" in field_config
+                "key_value" not in field_config
                 or not field_config["key_value"][index]
             ):
                 if flattened_data.get(full_path):
@@ -583,7 +583,7 @@ def _add_or_append_value(
     :param value_type: The field type
     :type value_type: `str`
     """
-    if not value_type in ["unix_nano", "string"]:
+    if value_type not in ["unix_nano", "string"]:
         raise ValueError("Unrecognised value_type")
 
     if value_type == "unix_nano":

--- a/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/json_data_converter.py
@@ -573,13 +573,13 @@ def _get_value_type(field_config: FieldSpec) -> str:
 
     if not isinstance(value_type, str):
         raise TypeError(
-            f"value_type should be a string, got {type(value_type)} instead."
+            f"value_type should be a string, got '{type(value_type)}' instead."
         )
 
     if value_type not in expected_value_types:
         raise ValueError(
             "Supported value types include "
-            f"'{','.join(expected_value_types)}', got {value_type} instead."
+            f"'{','.join(expected_value_types)}', got '{value_type}' instead."
         )
     return value_type
 

--- a/tel2puml/find_unique_graphs/otel_ingestion/otel_data_model.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/otel_data_model.py
@@ -1,6 +1,6 @@
 """Module containing classes to ingest OTel data into a data holder."""
 
-from typing import NamedTuple, Optional, TypedDict, Union
+from typing import NamedTuple, Optional, TypedDict
 
 from sqlalchemy import (
     Column,

--- a/tel2puml/find_unique_graphs/otel_ingestion/otel_data_model.py
+++ b/tel2puml/find_unique_graphs/otel_ingestion/otel_data_model.py
@@ -113,13 +113,13 @@ class SpanSpec(TypedDict):
     key_paths: list[str]
 
 
-class FieldSpec(TypedDict):
+class FieldSpec(TypedDict, total=False):
     """Typed dict for FieldSpec."""
 
     key_paths: list[str]
-    key_value: Optional[list[Optional[str]]]
-    value_paths: Optional[list[Optional[str]]]
-    value_type: Union[str, int]
+    key_value: list[Optional[str]]
+    value_paths: list[Optional[str]]
+    value_type: str
 
 
 class JSONDataSourceConfig(TypedDict):

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -354,3 +354,8 @@ def test_add_or_append_value() -> None:
     _add_or_append_value("name", "1.0", result, "string")
     assert len(result) == 1
     assert result["name"] == "Frontend 1.0"
+
+    # test incorrect value_type
+    result = {}
+    with pytest.raises(ValueError):
+        _add_or_append_value("span_id", "001", result, "invaid_type")

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -357,7 +357,7 @@ class TestProcessHeaderTags:
         assert len(result_dict) == 1
         assert result_dict["job_name"] == "001"
 
-        # Test multiple key_paths with values after a list
+        # Test multiple key_paths with nested values before and after list
         field_config: FieldSpec = {
             "key_paths": [
                 "HEADER:resource:attributes::key:nested_key",

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -19,6 +19,7 @@ from tel2puml.find_unique_graphs.otel_ingestion.json_data_converter import (
     _add_or_append_value,
     _find_matching_header_value,
     _handle_data_from_header,
+    _get_key_value,
 )
 from tel2puml.find_unique_graphs.otel_ingestion.otel_data_model import (
     IngestDataConfig,
@@ -493,3 +494,30 @@ def test_add_or_append_value() -> None:
     result = {}
     with pytest.raises(ValueError):
         _add_or_append_value("span_id", "001", result, "invaid_type")
+
+
+def test_get_key_value() -> None:
+    """Tests the function _get_key_value"""
+
+    # Test with correct field spec
+    field_spec = {"key_value": ["value1", "value2", "value3"]}
+    assert _get_key_value(field_spec, 1) == "value2"
+
+    # Test with no key_value field
+    field_spec = {"key_paths": ["path1"]}
+    with pytest.raises(KeyError, match="key_value field not set."):
+        _get_key_value(field_spec, 0)
+
+    # Test with index out of range
+    field_spec = {"key_value": ["value1", "value2"]}
+    with pytest.raises(
+        IndexError, match="Index 5 is out of range for key_value"
+    ):
+        _get_key_value(field_spec, 5)
+
+    # Test with empty key_value
+    field_spec = {"key_value": ["value1", None, "value3"]}
+    with pytest.raises(
+        ValueError, match="key_value at index 1 is empty or None"
+    ):
+        _get_key_value(field_spec, 1)

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -15,6 +15,7 @@ from tel2puml.find_unique_graphs.otel_ingestion.json_data_converter import (
     _build_nested_dict,
     _extract_nested_value,
     process_header,
+    _get_value_type,
 )
 from tel2puml.find_unique_graphs.otel_ingestion.otel_data_model import (
     IngestDataConfig,
@@ -298,3 +299,18 @@ class TestProcessHeaders:
         assert header_dict["scope_spans"] == flatdict.FlatterDict(
             {"scope": {"name": "TestJob"}}
         )
+
+
+class TestProcessHeaderTags:
+    """Tests for processing header tags within span field_mapping"""
+
+
+def test_get_value_type() -> None:
+    """Tests the function _get_value_type"""
+
+    field_config = {"key_paths": ["span_id"], "value_type": "string"}
+    assert _get_value_type(field_config) == "string"
+
+    field_config = {"key_paths": ["span_id"]}
+    with pytest.raises(KeyError):
+        _get_value_type(field_config)

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -23,6 +23,7 @@ from tel2puml.find_unique_graphs.otel_ingestion.json_data_converter import (
 from tel2puml.find_unique_graphs.otel_ingestion.otel_data_model import (
     IngestDataConfig,
     JSONDataSourceConfig,
+    FieldSpec,
 )
 
 
@@ -391,7 +392,7 @@ class TestProcessHeaderTags:
         """Tests for the function _handle_data_from_header"""
 
         field_name = "job_name"
-        field_config = {
+        field_config: FieldSpec = {
             "key_paths": [
                 "HEADER:resource:attributes::key",
                 "HEADER:resource:attributes::key",
@@ -403,7 +404,7 @@ class TestProcessHeaderTags:
             ],
             "value_type": "string",
         }
-        result_dict = {}
+        result_dict: dict[str, Any] = {}
         header_dict = {
             "resource:attributes": flatdict.FlatterDict(
                 [
@@ -440,7 +441,10 @@ def test_get_value_type() -> None:
     """Tests the function _get_value_type"""
 
     # Test with existing field
-    field_config = {"key_paths": ["span_id"], "value_type": "string"}
+    field_config: FieldSpec = {
+        "key_paths": ["span_id"],
+        "value_type": "string",
+    }
     assert _get_value_type(field_config) == "string"
 
     # Test with non-existing field
@@ -453,7 +457,7 @@ def test_add_or_append_value() -> None:
     """Tests the function _add_or_append_value"""
 
     # test adding unix nano, value int
-    result = {}
+    result: dict[str, Any] = {}
     _add_or_append_value(
         "start_timestamp", 1723544132228102912, result, "unix_nano"
     )

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -319,51 +319,12 @@ class TestProcessHeaderTags:
     def test_handle_data_from_header() -> None:
         """Tests for the function _handle_data_from_header"""
 
-        # Test simple case
-        header_dict = {"span_id": "001"}
-        field_config: FieldSpec = {
-            "key_paths": [
-                "HEADER:span_id",
-            ],
-            "value_type": "string",
-        }
-        result_dict: dict[str, Any] = {}
-        _handle_data_from_header(
-            target_field_name="job_name",
-            field_config=field_config,
-            config_index=0,
-            result_dict=result_dict,
-            header_data=header_dict,
-            initial_header_key=field_config["key_paths"][0].split("::")[-1],
-            full_header_path=field_config["key_paths"][0],
-        )
-        assert len(result_dict) == 1
-        assert result_dict["job_name"] == "001"
-
-        # Test nested dict case - dict is flattened before this function,
-        # hence "nested:span_id"
-        header_dict = {"nested:span_id": "001"}
-        field_config = {
-            "key_paths": [
-                "HEADER:nested:span_id",
-            ],
-            "value_type": "string",
-        }
-        result_dict = {}
-        _handle_data_from_header(
-            target_field_name="job_name",
-            field_config=field_config,
-            config_index=0,
-            result_dict=result_dict,
-            header_data=header_dict,
-            initial_header_key=field_config["key_paths"][0].split("::")[-1],
-            full_header_path=field_config["key_paths"][0],
-        )
-        assert len(result_dict) == 1
-        assert result_dict["job_name"] == "001"
+        # Simple cases such as key_paths = [key:nested_key] are not
+        # covered here as '::' is required in a key_path for this function
+        # to be reached.
 
         # Test multiple key_paths with nested values before and after list
-        field_config = {
+        field_config: FieldSpec = {
             "key_paths": [
                 "HEADER:resource:attributes::key:nested_key",
                 "HEADER:resource:attributes::key",
@@ -375,7 +336,7 @@ class TestProcessHeaderTags:
             ],
             "value_type": "string",
         }
-        result_dict = {}
+        result_dict: dict[str, Any] = {}
         header_dict = {
             "resource:attributes": flatdict.FlatterDict(
                 [

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -23,7 +23,7 @@ from tel2puml.find_unique_graphs.otel_ingestion.json_data_converter import (
     _handle_data_from_header,
     _get_key_value,
     _get_value_path,
-    process_spans
+    process_spans,
 )
 from tel2puml.find_unique_graphs.otel_ingestion.otel_data_model import (
     IngestDataConfig,
@@ -343,7 +343,7 @@ class TestProcessHeaderTags:
         # Test nested dict case - dict is flattened before this function,
         # hence "nested:span_id"
         header_dict = {"nested:span_id": "001"}
-        field_config: FieldSpec = {
+        field_config = {
             "key_paths": [
                 "HEADER:nested:span_id",
             ],
@@ -363,7 +363,7 @@ class TestProcessHeaderTags:
         assert result_dict["job_name"] == "001"
 
         # Test multiple key_paths with nested values before and after list
-        field_config: FieldSpec = {
+        field_config = {
             "key_paths": [
                 "HEADER:resource:attributes::key:nested_key",
                 "HEADER:resource:attributes::key",
@@ -513,14 +513,6 @@ def test_get_value_type() -> None:
         "value_type": "invalid",
     }
     with pytest.raises(ValueError):
-        _get_value_type(field_config)
-
-    # Test with non string
-    field_config = {
-        "key_paths": ["span_id"],
-        "value_type": 111,
-    }
-    with pytest.raises(TypeError):
         _get_value_type(field_config)
 
 
@@ -717,8 +709,7 @@ class TestProcessSpans:
         caplog.set_level(logging.WARNING)
         process_spans(json_config, sample_data)
         assert (
-            "Encountered an empty list whilst processing spans."
-            in caplog.text
+            "Encountered an empty list whilst processing spans." in caplog.text
         )
 
         # Test more than one scope_spans

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -20,6 +20,7 @@ from tel2puml.find_unique_graphs.otel_ingestion.json_data_converter import (
     _find_matching_header_value,
     _handle_data_from_header,
     _get_key_value,
+    _get_value_path,
 )
 from tel2puml.find_unique_graphs.otel_ingestion.otel_data_model import (
     IngestDataConfig,
@@ -521,3 +522,29 @@ def test_get_key_value() -> None:
         ValueError, match="key_value at index 1 should not return None."
     ):
         _get_key_value(field_spec, 1)
+
+def test_get_value_path() -> None:
+    """Tests the function _get_value_path"""
+
+    # Test with correct field spec
+    field_spec = {"value_paths": ["value1", "value2", "value3"]}
+    assert _get_value_path(field_spec, 1) == "value2"
+
+    # Test with no key_value field
+    field_spec = {"key_paths": ["path1"]}
+    with pytest.raises(KeyError, match="value_paths field not set."):
+        _get_value_path(field_spec, 0)
+
+    # Test with index out of range
+    field_spec = {"value_paths": ["value1", "value2"]}
+    with pytest.raises(
+        IndexError, match="Index 5 is out of range for value_paths."
+    ):
+        _get_value_path(field_spec, 5)
+
+    # Test with empty key_value
+    field_spec = {"value_paths": ["value1", None, "value3"]}
+    with pytest.raises(
+        ValueError, match="value_path at index 1 is empty or None."
+    ):
+        _get_value_path(field_spec, 1)

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -448,16 +448,32 @@ class TestProcessHeaderTags:
 def test_get_value_type() -> None:
     """Tests the function _get_value_type"""
 
-    # Test with existing field
+    # Test with correct field
     field_config: FieldSpec = {
         "key_paths": ["span_id"],
         "value_type": "string",
     }
     assert _get_value_type(field_config) == "string"
 
-    # Test with non-existing field
+    # Test with non-existing value_type field
     field_config = {"key_paths": ["span_id"]}
     with pytest.raises(KeyError):
+        _get_value_type(field_config)
+
+    # Test with invalid type
+    field_config = {
+        "key_paths": ["span_id"],
+        "value_type": "invalid",
+    }
+    with pytest.raises(ValueError):
+        _get_value_type(field_config)
+
+    # Test with non string
+    field_config = {
+        "key_paths": ["span_id"],
+        "value_type": 111,
+    }
+    with pytest.raises(TypeError):
         _get_value_type(field_config)
 
 
@@ -497,11 +513,6 @@ def test_add_or_append_value() -> None:
     assert len(result) == 1
     assert result["name"] == "Frontend 1.0"
 
-    # test incorrect value_type
-    result = {}
-    with pytest.raises(ValueError):
-        _add_or_append_value("span_id", "001", result, "invalid_type")
-
 
 def test_get_key_value() -> None:
     """Tests the function _get_key_value"""
@@ -537,7 +548,7 @@ def test_get_value_path() -> None:
     field_spec: FieldSpec = {"value_paths": ["value1", "value2", "value3"]}
     assert _get_value_path(field_spec, 1) == "value2"
 
-    # Test with no key_value field
+    # Test with no value_paths field
     field_spec = {"key_paths": ["path1"]}
     with pytest.raises(KeyError, match="value_paths field not set."):
         _get_value_path(field_spec, 0)
@@ -549,7 +560,7 @@ def test_get_value_path() -> None:
     ):
         _get_value_path(field_spec, 5)
 
-    # Test with empty key_value
+    # Test with empty value_paths
     field_spec = {"value_paths": ["value1", None, "value3"]}
     with pytest.raises(
         ValueError, match="value_path at index 1 is empty or None."

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -493,7 +493,7 @@ def test_add_or_append_value() -> None:
     # test incorrect value_type
     result = {}
     with pytest.raises(ValueError):
-        _add_or_append_value("span_id", "001", result, "invaid_type")
+        _add_or_append_value("span_id", "001", result, "invalid_type")
 
 
 def test_get_key_value() -> None:
@@ -518,6 +518,6 @@ def test_get_key_value() -> None:
     # Test with empty key_value
     field_spec = {"key_value": ["value1", None, "value3"]}
     with pytest.raises(
-        ValueError, match="key_value at index 1 is empty or None"
+        ValueError, match="key_value at index 1 should not return None."
     ):
         _get_key_value(field_spec, 1)

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -349,7 +349,7 @@ class TestProcessHeaderTags:
             ],
             "value_type": "string",
         }
-        result_dict: dict[str, Any] = {}
+        result_dict = {}
         _handle_data_from_header(
             target_field_name="job_name",
             field_config=field_config,

--- a/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
+++ b/tests/tel2puml/find_unique_graphs/test_json_data_converter.py
@@ -311,85 +311,6 @@ class TestProcessHeaderTags:
     """Tests for processing header tags within span field_mapping"""
 
     @staticmethod
-    def test_find_matching_header_value() -> None:
-        """Tests for the function _find_matching_header_value"""
-
-        header_level = flatdict.FlatterDict(
-            [
-                {
-                    "key": "service.name",
-                    "value": {"Value": {"StringValue": "Frontend"}},
-                },
-                {
-                    "key": "service.version",
-                    "value": {"Value": {"StringValue": "1.0"}},
-                },
-            ]
-        )
-
-        # Test matching header success
-        assert (
-            _find_matching_header_value(
-                header_level=header_level,
-                target_key="key",
-                field_config={
-                    "key_value": ["service.name"],
-                },
-                config_index=0,
-                header_key="value:Value:StringValue",
-            )
-            == "Frontend"
-        )
-
-        # Test more than one header value
-        assert (
-            _find_matching_header_value(
-                header_level=header_level,
-                target_key="key",
-                field_config={
-                    "key_value": ["service.name", "service.version"],
-                },
-                config_index=1,
-                header_key="value:Value:StringValue",
-            )
-            == "1.0"
-        )
-
-        # Test inalid target key - no match found
-        with pytest.raises(KeyError, match="No matching value found"):
-            _find_matching_header_value(
-                header_level=header_level,
-                target_key="invalid_key",
-                field_config={
-                    "key_value": ["service.name"],
-                },
-                config_index=0,
-                header_key="value:Value:StringValue",
-            )
-
-        # Test invalid header_key
-        with pytest.raises(KeyError, match="invalid key"):
-            _find_matching_header_value(
-                header_level=header_level,
-                target_key="key",
-                field_config={"key_value": ["service.name"]},
-                config_index=0,
-                header_key="value:Value:Invalid",
-            )
-
-        # Test empty header
-        with pytest.raises(
-            ValueError, match="No data within header dictionary"
-        ):
-            _find_matching_header_value(
-                header_level={},
-                target_key="key",
-                field_config={"key_value": ["service.name"]},
-                config_index=0,
-                header_key="value:Value:Invalid",
-            )
-
-    @staticmethod
     def test_handle_data_from_header() -> None:
         """Tests for the function _handle_data_from_header"""
 
@@ -586,7 +507,7 @@ def test_get_key_value() -> None:
     """Tests the function _get_key_value"""
 
     # Test with correct field spec
-    field_spec = {"key_value": ["value1", "value2", "value3"]}
+    field_spec: FieldSpec = {"key_value": ["value1", "value2", "value3"]}
     assert _get_key_value(field_spec, 1) == "value2"
 
     # Test with no key_value field
@@ -613,7 +534,7 @@ def test_get_value_path() -> None:
     """Tests the function _get_value_path"""
 
     # Test with correct field spec
-    field_spec = {"value_paths": ["value1", "value2", "value3"]}
+    field_spec: FieldSpec = {"value_paths": ["value1", "value2", "value3"]}
     assert _get_value_path(field_spec, 1) == "value2"
 
     # Test with no key_value field


### PR DESCRIPTION
This PR adds tests for functions involved with handling HEADER tags within span field mapping.

Two new functions are created within json data converter that handle getting the values from the field_mapping config:
- get_key_value
- get_value_path

The following functions have been tested:
- handle_data_from_header
- find_matching_header_value
- get_value_type
- add_or_append_value
- get_key_value
- get_value_path