### PR TITLE
55 function to order groups of otelevent by start timestamps

### DIFF
--- a/tel2puml/sequence_otel_v2.py
+++ b/tel2puml/sequence_otel_v2.py
@@ -1,0 +1,29 @@
+"""Module to sequence OTel data from grouped OTelEvents"""
+
+from tel2puml.find_unique_graphs.otel_ingestion.otel_data_model import (
+    OTelEvent,
+)
+
+
+def order_groups_by_start_timestamp(
+    groups: list[list[OTelEvent]],
+) -> list[list[OTelEvent]]:
+    """Order groups by start timestamp.
+
+    :param groups: A list of groups of OTelEvents.
+    :type groups: `list`[`list`[`OTelEvent`]]
+    :return: A list of groups of OTelEvents ordered by start timestamp.
+    :rtype: `list`[`list`[`OTelEvent`]]
+    """
+    try:
+        return sorted(
+            [
+                sorted(group, key=lambda x: x.start_timestamp)
+                for group in groups
+            ],
+            key=lambda x: x[0].start_timestamp,
+        )
+    except IndexError:
+        raise ValueError(
+            "Groups in the input list must contain at least one OTelEvent."
+        )

--- a/tests/tel2puml/test_sequence_otel_v2.py
+++ b/tests/tel2puml/test_sequence_otel_v2.py
@@ -1,0 +1,70 @@
+"""Test the tel2puml.sequence_otel_v2 module."""
+
+import pytest
+
+from tel2puml.sequence_otel_v2 import order_groups_by_start_timestamp
+from tel2puml.find_unique_graphs.otel_ingestion.otel_data_model import (
+    OTelEvent,
+)
+
+
+def test_order_groups_by_start_timestamp() -> None:
+    """Test order_groups_by_start_timestamp."""
+    groups = [
+        [
+            OTelEvent(
+                job_name="job_name",
+                job_id="job_id",
+                event_type="event_type",
+                event_id="event_id",
+                start_timestamp=i * 2 + j,
+                end_timestamp=i * 2 + j + 1,
+                application_name="application_name",
+                parent_event_id=None,
+                child_event_ids=None,
+            )
+            for j in reversed(range(2))
+        ]
+        for i in reversed(range(3))
+    ]
+    ordered_groups = order_groups_by_start_timestamp(groups)
+    expected_ordered_groups = [
+        [
+            OTelEvent(
+                job_name="job_name",
+                job_id="job_id",
+                event_type="event_type",
+                event_id="event_id",
+                start_timestamp=i * 2 + j,
+                end_timestamp=i * 2 + j + 1,
+                application_name="application_name",
+                parent_event_id=None,
+                child_event_ids=None,
+            )
+            for j in range(2)
+        ]
+        for i in range(3)
+    ]
+    assert ordered_groups == expected_ordered_groups
+    # test case where one group is empty
+    with pytest.raises(ValueError):
+        order_groups_by_start_timestamp(
+            [
+                [],
+                [
+                    OTelEvent(
+                        job_name="job_name",
+                        job_id="job_id",
+                        event_type="event_type",
+                        event_id="event_id",
+                        start_timestamp=0,
+                        end_timestamp=1,
+                        application_name="application_name",
+                        parent_event_id=None,
+                        child_event_ids=None,
+                    )
+                ],
+            ]
+        )
+    # test case where there are no groups
+    assert order_groups_by_start_timestamp([]) == []


### PR DESCRIPTION
PR to implement a function that orders groups of OTelEvents by start timestamp using the earliest start timestamp of each group