### PR TITLE
105-interface-for-sequencer-to-ingest-stream-of-streams-of-otelevent

### DIFF
--- a/tel2puml/sequence_otel_v2.py
+++ b/tel2puml/sequence_otel_v2.py
@@ -292,8 +292,6 @@ def sequence_otel_job_id_streams(
                 event_id_map[otel_event.event_id] = otel_event
             yield event_id_map
 
-    yield sequence_otel_jobs(
-        job_ids_to_eventid_to_otelevent_map(
-            job_id_streams, async_flag, event_to_async_group_map
-        )
+    yield from sequence_otel_jobs(
+        job_ids_to_eventid_to_otelevent_map(job_id_streams), async_flag, event_to_async_group_map
     )

--- a/tel2puml/sequence_otel_v2.py
+++ b/tel2puml/sequence_otel_v2.py
@@ -265,14 +265,20 @@ def sequence_otel_job_id_streams(
     """
     Sequence OTel events in multiple jobs.
 
-    :param job_id_streams: A generator of generators, where each inner generator yields OTelEvent objects grouped by job ID.
-    :type job_id_streams: `Generator`[`Generator`[:class:`OTelEvent`, `Any`, `None`], `Any`, `None`]
-    :param async_flag: A flag indicating whether to sequence event groups asynchronously or not, defaults to False.
+    :param job_id_streams: A generator of generators, where each inner
+    generator yields OTelEvent objects grouped by job ID.
+    :type job_id_streams: `Generator`[`Generator`[:class:`OTelEvent`, `Any`,
+    `None`], `Any`, `None`]
+    :param async_flag: A flag indicating whether to sequence event groups
+    asynchronously or not, defaults to False.
     :type async_flag: `bool`
-    :param event_to_async_group_map: A dictionary mapping event types to groups of events that occur asynchronously, defaults to None.
-    :type event_to_async_group_map: `dict`[`str`, `dict`[`str`, `str`]] | `None`
+    :param event_to_async_group_map: A dictionary mapping event types to
+    groups of events that occur asynchronously, defaults to None.
+    :type event_to_async_group_map: `dict`[`str`, `dict`[`str`, `str`]] |
+    `None`
     :return: A generator of jobs (generators) of PVEvents.
-    :rtype: `Generator`[`Generator`[:class:`PVEvent`, `Any`, `None`], `Any`, `None`]
+    :rtype: `Generator`[`Generator`[:class:`PVEvent`, `Any`, `None`], `Any`,
+    `None`]
     """
 
     def job_ids_to_eventid_to_otelevent_map(
@@ -281,9 +287,12 @@ def sequence_otel_job_id_streams(
         """
         Creates a mapping from event IDs to OTelEvent objects for each job.
 
-        :param job_id_streams: A generator of generators, where each inner generator yields OTelEvent objects grouped by job ID.
-        :type job_id_streams: `Generator`[`Generator`[:class:`OTelEvent`, `Any`, `None`], `Any`, `None`]
-        :return: A generator of dictionaries mapping event IDs to OTelEvent objects for each job.
+        :param job_id_streams: A generator of generators, where each inner
+        generator yields OTelEvent objects grouped by job ID.
+        :type job_id_streams: `Generator`[`Generator`[:class:`OTelEvent`,
+        `Any`, `None`], `Any`, `None`]
+        :return: A generator of dictionaries mapping event IDs to OTelEvent
+        objects for each job.
         :rtype: `Generator`[`dict`[`str`, :class:`OTelEvent`], `Any`, `None`]
         """
         for job_group in job_id_streams:
@@ -293,5 +302,7 @@ def sequence_otel_job_id_streams(
             yield event_id_map
 
     yield from sequence_otel_jobs(
-        job_ids_to_eventid_to_otelevent_map(job_id_streams), async_flag, event_to_async_group_map
+        job_ids_to_eventid_to_otelevent_map(job_id_streams),
+        async_flag,
+        event_to_async_group_map,
     )

--- a/tel2puml/sequence_otel_v2.py
+++ b/tel2puml/sequence_otel_v2.py
@@ -280,29 +280,26 @@ def sequence_otel_job_id_streams(
     :rtype: `Generator`[`Generator`[:class:`PVEvent`, `Any`, `None`], `Any`,
     `None`]
     """
-
-    def job_ids_to_eventid_to_otelevent_map(
-        job_id_streams: Generator[Generator[OTelEvent, Any, None], Any, None],
-    ) -> Generator[dict[str, OTelEvent], Any, None]:
-        """
-        Creates a mapping from event IDs to OTelEvent objects for each job.
-
-        :param job_id_streams: A generator of generators, where each inner
-        generator yields OTelEvent objects grouped by job ID.
-        :type job_id_streams: `Generator`[`Generator`[:class:`OTelEvent`,
-        `Any`, `None`], `Any`, `None`]
-        :return: A generator of dictionaries mapping event IDs to OTelEvent
-        objects for each job.
-        :rtype: `Generator`[`dict`[`str`, :class:`OTelEvent`], `Any`, `None`]
-        """
-        for job_group in job_id_streams:
-            event_id_map = {}
-            for otel_event in job_group:
-                event_id_map[otel_event.event_id] = otel_event
-            yield event_id_map
-
     yield from sequence_otel_jobs(
         job_ids_to_eventid_to_otelevent_map(job_id_streams),
         async_flag,
         event_to_async_group_map,
     )
+
+
+def job_ids_to_eventid_to_otelevent_map(
+    job_id_streams: Generator[Generator[OTelEvent, Any, None], Any, None],
+) -> Generator[dict[str, OTelEvent], Any, None]:
+    """
+    Creates a mapping from event IDs to OTelEvent objects for each job.
+
+    :param job_id_streams: A generator of generators, where each inner
+    generator yields OTelEvent objects grouped by job ID.
+    :type job_id_streams: `Generator`[`Generator`[:class:`OTelEvent`,
+    `Any`, `None`], `Any`, `None`]
+    :return: A generator of dictionaries mapping event IDs to OTelEvent
+    objects for each job.
+    :rtype: `Generator`[`dict`[`str`, :class:`OTelEvent`], `Any`, `None`]
+    """
+    for job_group in job_id_streams:
+        yield {otel_event.event_id: otel_event for otel_event in job_group}

--- a/tests/tel2puml/test_sequence_otel_v2.py
+++ b/tests/tel2puml/test_sequence_otel_v2.py
@@ -13,6 +13,7 @@ from tel2puml.sequence_otel_v2 import (
     sequence_otel_event_job,
     sequence_otel_jobs,
     sequence_otel_job_id_streams,
+    job_ids_to_eventid_to_otelevent_map,
 )
 from tel2puml.otel_to_pv.otel_to_pv_types import OTelEvent
 from tel2puml.tel2puml_types import PVEvent
@@ -440,3 +441,26 @@ class TestSeqeunceOTelJobs:
         assert self.sort_pv_events(actual_pv_events) == self.sort_pv_events(
             expected_pv_events
         )
+
+    def test_job_ids_to_eventid_to_otelevent_map(self) -> None:
+        """Tests for the function job_ids_to_eventid_to_otelevent_map"""
+
+        def job_id_streams() -> (
+            Generator[Generator[OTelEvent, None, None], None, None]
+        ):
+            """Create a generator of generators of OTelEvents"""
+            event_group = [event for event in events.values()]
+            yield (event for event in event_group)
+
+        events = self.events_with_root()
+
+        expected_mappings = []
+        expected_mappings.append(
+            {event.event_id: event for event in events.values()}
+        )
+
+        event_dict_gen = job_ids_to_eventid_to_otelevent_map(job_id_streams())
+        actual_mappings = list(event_dict_gen)
+
+        assert len(actual_mappings) == len(expected_mappings)
+        assert actual_mappings == expected_mappings

--- a/tests/tel2puml/test_sequence_otel_v2.py
+++ b/tests/tel2puml/test_sequence_otel_v2.py
@@ -1,5 +1,6 @@
 """Test the tel2puml.sequence_otel_v2 module."""
-from typing import Iterable
+
+from typing import Iterable, Generator
 
 import pytest
 
@@ -10,7 +11,8 @@ from tel2puml.sequence_otel_v2 import (
     sequence_otel_event_ancestors,
     get_root_event_from_event_id_to_event_map,
     sequence_otel_event_job,
-    sequence_otel_jobs
+    sequence_otel_jobs,
+    sequence_otel_job_id_streams,
 )
 from tel2puml.otel_to_pv.otel_to_pv_types import OTelEvent
 from tel2puml.tel2puml_types import PVEvent
@@ -19,6 +21,7 @@ from tel2puml.utils import unix_nano_to_pv_string
 
 class TestSeqeunceOTelJobs:
     """Test the sequence_otel_v2 module."""
+
     @staticmethod
     def events() -> dict[str, OTelEvent]:
         """Return a dictionary of OTelEvents."""
@@ -32,9 +35,9 @@ class TestSeqeunceOTelJobs:
                 end_timestamp=i * 2 + j + 1,
                 application_name="application_name",
                 parent_event_id="root" if i == 0 else f"{i - 1}{0}",
-                child_event_ids=[] if i == 2 or j == 1 else [
-                    f"{i + 1}0", f"{i + 1}1"
-                ],
+                child_event_ids=(
+                    [] if i == 2 or j == 1 else [f"{i + 1}0", f"{i + 1}1"]
+                ),
             )
             for i in range(3)
             for j in range(2)
@@ -65,23 +68,14 @@ class TestSeqeunceOTelJobs:
         """Return groups of OTelEvents in reverse order."""
         events = self.events()
         return [
-            [
-                events[f"{i}{j}"]
-                for j in reversed(range(2))
-            ]
+            [events[f"{i}{j}"] for j in reversed(range(2))]
             for i in reversed(range(3))
         ]
 
     def correct_order_groups(self) -> list[list[OTelEvent]]:
         """Return a list of groups of OTelEvents in the correct order."""
         events = self.events()
-        return [
-            [
-                events[f"{i}{j}"]
-                for j in range(2)
-            ]
-            for i in range(3)
-        ]
+        return [[events[f"{i}{j}"] for j in range(2)] for i in range(3)]
 
     def synchronous_previous_event_ids(self) -> dict[str, list[str]]:
         """Return a dictionary mapping event ids to a list of previous event
@@ -123,8 +117,7 @@ class TestSeqeunceOTelJobs:
         }
 
     def event_to_async_group_map(self) -> dict[str, dict[str, str]]:
-        """Return a dictionary mapping event types to async groups.
-        """
+        """Return a dictionary mapping event types to async groups."""
         return {
             "root_event": {
                 "event_type_00": "group_0",
@@ -150,8 +143,7 @@ class TestSeqeunceOTelJobs:
         previous_event_ids: dict[str, list[str]],
         events: dict[str, OTelEvent],
     ) -> list[PVEvent]:
-        """Return a list of PVEvents.
-        """
+        """Return a list of PVEvents."""
         return self.sort_pv_events(
             [
                 PVEvent(
@@ -269,23 +261,32 @@ class TestSeqeunceOTelJobs:
             == self.synchronous_previous_event_ids()
         )
         # async flag set to True
-        assert sequence_otel_event_ancestors(
-            events["root"], events, async_flag=True
-        ) == self.async_previous_event_ids()
+        assert (
+            sequence_otel_event_ancestors(
+                events["root"], events, async_flag=True
+            )
+            == self.async_previous_event_ids()
+        )
         # async information is provided
         event_to_async_group_map = self.event_to_async_group_map()
-        assert sequence_otel_event_ancestors(
-            events["root"],
-            events,
-            event_to_async_group_map=event_to_async_group_map,
-        ) == self.prior_async_information_event_ids()
+        assert (
+            sequence_otel_event_ancestors(
+                events["root"],
+                events,
+                event_to_async_group_map=event_to_async_group_map,
+            )
+            == self.prior_async_information_event_ids()
+        )
         # async information is provided and async flag is set to True
-        assert sequence_otel_event_ancestors(
-            events["root"],
-            events,
-            event_to_async_group_map=event_to_async_group_map,
-            async_flag=True,
-        ) == self.async_previous_event_ids()
+        assert (
+            sequence_otel_event_ancestors(
+                events["root"],
+                events,
+                event_to_async_group_map=event_to_async_group_map,
+                async_flag=True,
+            )
+            == self.async_previous_event_ids()
+        )
         # raise error if child event ids has not been set
         with pytest.raises(ValueError):
             sequence_otel_event_ancestors(
@@ -376,3 +377,37 @@ class TestSeqeunceOTelJobs:
             assert self.sort_pv_events(pv_events) == self.pv_events(
                 self.async_previous_event_ids(), events
             )
+
+    def test_sequence_otel_job_id_streams(self) -> None:
+        """Tests for the function sequence_otel_job_id_streams"""
+
+        # Test 1: Default parameters
+        events = self.events_with_root()
+
+        def job_id_streams() -> (
+            Generator[Generator[OTelEvent, None, None], None, None]
+        ):
+            job_group = [
+                events["root"],
+                events["00"],
+                events["01"],
+                events["10"],
+                events["11"],
+                events["20"],
+                events["21"],
+            ]
+            yield (event for event in job_group)
+
+        expected_pv_events = self.pv_events(
+            self.synchronous_previous_event_ids(), events
+        )
+
+        pv_event_generators = sequence_otel_job_id_streams(job_id_streams())
+
+        actual_pv_events = []
+        for pv_event_gen in pv_event_generators:
+            actual_pv_events.extend(list(pv_event_gen))
+
+        assert self.sort_pv_events(actual_pv_events) == self.sort_pv_events(
+            expected_pv_events
+        )


### PR DESCRIPTION
This PR adds an interface within the otel sequencer module that takes in a generator of generator of OTelEvents and returns a generator of generator of PVEvents.