### PR TITLE
116-function-to-take-config-and-produce-pv-events-grouped-by-job-name

### DIFF
--- a/tests/tel2puml/otel_to_pv/test_sequence_otel_v2.py
+++ b/tests/tel2puml/otel_to_pv/test_sequence_otel_v2.py
@@ -516,12 +516,11 @@ class TestSeqeunceOTelJobs:
 
         assert result
         events = []
-        valid_job_names = {"test_name"}
         valid_event_ids = [f"{i}_{j}" for i in range(5) for j in range(2)]
         valid_job_ids = {f"test_id_{i}" for i in range(5)}
         job_id_count: dict[str, int] = {}
         for job_name, job_generator in result:
-            assert job_name in valid_job_names
+            assert job_name == "test_name"
             for otel_event_generator in job_generator:
                 for otel_event in otel_event_generator:
                     job_id_count.setdefault(otel_event.job_id, 0)
@@ -534,7 +533,7 @@ class TestSeqeunceOTelJobs:
 
         assert len(events) == 10
         assert all(isinstance(event, OTelEvent) for event in events)
-        assert all(count == 2 for count in job_id_count.values())
+        assert all(job_id_count[job_id] == 2 for job_id in valid_job_ids)
         assert len(valid_event_ids) == 0
 
         # Test 2: ingest_data = True
@@ -545,7 +544,7 @@ class TestSeqeunceOTelJobs:
             config, ingest_data=True
         )
         events = []
-        valid_job_names = {"Backend TestJob", "Frontend TestJob"}
+        valid_job_names = ["Backend TestJob", "Frontend TestJob"]
         valid_job_ids = {
             "0_trace_id_1 4.8",
             "1_trace_id_1 4.8",
@@ -559,7 +558,8 @@ class TestSeqeunceOTelJobs:
             for k in range(2)
         ]
         job_id_count = {}
-        for job_name, job_generator in result:
+        for i, (job_name, job_generator) in enumerate(result):
+            assert job_name == valid_job_names[i]
             for otel_event_generator in job_generator:
                 for otel_event in otel_event_generator:
                     job_id_count.setdefault(otel_event.job_id, 0)
@@ -571,7 +571,7 @@ class TestSeqeunceOTelJobs:
                     valid_event_ids.remove(otel_event.event_id)
         assert len(events) == 8
         assert all(isinstance(event, OTelEvent) for event in events)
-        assert all(count == 2 for count in job_id_count.values())
+        assert all(job_id_count[job_id] == 2 for job_id in valid_job_ids)
         assert len(valid_event_ids) == 0
 
         # Test 3: find_unique_graphs = True
@@ -581,14 +581,13 @@ class TestSeqeunceOTelJobs:
 
         assert result
         events = []
-        valid_job_names = {"test_name"}
         # job id test_id_0 is outside the config time buffer window, therefore
         # it is not included, reducing total events streamed to 8
         valid_event_ids = [f"{i}_{j}" for i in range(1, 5) for j in range(2)]
         valid_job_ids = {f"test_id_{i}" for i in range(1, 5)}
         job_id_count = {}
         for job_name, job_generator in result:
-            assert job_name in valid_job_names
+            assert job_name == "test_name"
             for otel_event_generator in job_generator:
                 for otel_event in otel_event_generator:
                     job_id_count.setdefault(otel_event.job_id, 0)
@@ -601,7 +600,7 @@ class TestSeqeunceOTelJobs:
 
         assert len(events) == 8
         assert all(isinstance(event, OTelEvent) for event in events)
-        assert all(count == 2 for count in job_id_count.values())
+        assert all(job_id_count[job_id] == 2 for job_id in valid_job_ids)
         assert len(valid_event_ids) == 0
 
     def test_otel_to_pv(
@@ -631,12 +630,11 @@ class TestSeqeunceOTelJobs:
         result = otel_to_pv(ingest_data_config)
 
         events = []
-        valid_job_names = {"test_name"}
         valid_event_ids = [f"{i}_{j}" for i in range(5) for j in range(2)]
         valid_job_ids = {f"test_id_{i}" for i in range(5)}
         job_id_count: dict[str, int] = {}
         for job_name, pv_event_streams in result:
-            assert job_name in valid_job_names
+            assert job_name == "test_name"
             for pv_event_gen in pv_event_streams:
                 for pv_event in pv_event_gen:
                     job_id_count.setdefault(pv_event["jobId"], 0)
@@ -647,7 +645,7 @@ class TestSeqeunceOTelJobs:
                     valid_event_ids.remove(pv_event["eventId"])
 
         assert len(events) == 10
-        assert all(count == 2 for count in job_id_count.values())
+        assert all(job_id_count[job_id] == 2 for job_id in valid_job_ids)
         assert len(valid_event_ids) == 0
 
         # Test 2: ingest_data = True
@@ -657,7 +655,7 @@ class TestSeqeunceOTelJobs:
         result = otel_to_pv(config, ingest_data=True)
 
         events = []
-        valid_job_names = {"Backend TestJob", "Frontend TestJob"}
+        valid_job_names = ["Backend TestJob", "Frontend TestJob"]
         valid_job_ids = {
             "0_trace_id_1 4.8",
             "1_trace_id_1 4.8",
@@ -671,8 +669,8 @@ class TestSeqeunceOTelJobs:
             for k in range(2)
         ]
         job_id_count = {}
-        for job_name, pv_event_streams in result:
-            assert job_name in valid_job_names
+        for i, (job_name, pv_event_streams) in enumerate(result):
+            assert job_name == valid_job_names[i]
             for pv_event_gen in pv_event_streams:
                 for pv_event in pv_event_gen:
                     job_id_count.setdefault(pv_event["jobId"], 0)
@@ -683,21 +681,20 @@ class TestSeqeunceOTelJobs:
                     valid_event_ids.remove(pv_event["eventId"])
 
         assert len(events) == 8
-        assert all(count == 2 for count in job_id_count.values())
+        assert all(job_id_count[job_id] == 2 for job_id in valid_job_ids)
         assert len(valid_event_ids) == 0
 
         # Test 3: find_unique_graphs = True
         result = otel_to_pv(ingest_data_config, find_unique_graphs=True)
 
         events = []
-        valid_job_names = {"test_name"}
         # job id test_id_0 is outside the config time buffer window, therefore
         # it is not included, reducing total events streamed to 8
         valid_event_ids = [f"{i}_{j}" for i in range(1, 5) for j in range(2)]
         valid_job_ids = {f"test_id_{i}" for i in range(1, 5)}
         job_id_count = {}
         for job_name, pv_event_streams in result:
-            assert job_name in valid_job_names
+            assert job_name == "test_name"
             for pv_event_gen in pv_event_streams:
                 for pv_event in pv_event_gen:
                     job_id_count.setdefault(pv_event["jobId"], 0)
@@ -708,7 +705,7 @@ class TestSeqeunceOTelJobs:
                     valid_event_ids.remove(pv_event["eventId"])
 
         assert len(events) == 8
-        assert all(count == 2 for count in job_id_count.values())
+        assert all(job_id_count[job_id] == 2 for job_id in valid_job_ids)
         assert len(valid_event_ids) == 0
 
         # Test 4: async_flag = True
@@ -718,7 +715,7 @@ class TestSeqeunceOTelJobs:
         valid_job_ids = {f"test_id_{i}" for i in range(5)}
         job_id_count = {}
         for job_name, pv_event_streams in result:
-            assert job_name in valid_job_names
+            assert job_name == "test_name"
             for pv_event_gen in pv_event_streams:
                 for pv_event in pv_event_gen:
                     job_id_count.setdefault(pv_event["jobId"], 0)
@@ -729,7 +726,7 @@ class TestSeqeunceOTelJobs:
                     valid_event_ids.remove(pv_event["eventId"])
 
         assert len(events) == 10
-        assert all(count == 2 for count in job_id_count.values())
+        assert all(job_id_count[job_id] == 2 for job_id in valid_job_ids)
         assert len(valid_event_ids) == 0
 
         # Test 5: event_to_async_group_map provided
@@ -743,6 +740,7 @@ class TestSeqeunceOTelJobs:
         valid_job_ids = {f"test_id_{i}" for i in range(5)}
         job_id_count = {}
         for job_name, pv_event_streams in result:
+            assert job_name == "test_name"
             for pv_event_gen in pv_event_streams:
                 for pv_event in pv_event_gen:
                     job_id_count.setdefault(pv_event["jobId"], 0)
@@ -753,5 +751,5 @@ class TestSeqeunceOTelJobs:
                     valid_event_ids.remove(pv_event["eventId"])
 
         assert len(events) == 10
-        assert all(count == 2 for count in job_id_count.values())
+        assert all(job_id_count[job_id] == 2 for job_id in valid_job_ids)
         assert len(valid_event_ids) == 0

--- a/tests/tel2puml/otel_to_pv/test_sequence_otel_v2.py
+++ b/tests/tel2puml/otel_to_pv/test_sequence_otel_v2.py
@@ -18,6 +18,7 @@ from tel2puml.otel_to_pv.sequence_otel_v2 import (
     sequence_otel_job_id_streams,
     job_ids_to_eventid_to_otelevent_map,
     config_to_otel_job_name_group_streams,
+    otel_to_pv,
 )
 from tel2puml.otel_to_pv.otel_to_pv_types import OTelEvent
 from tel2puml.tel2puml_types import PVEvent
@@ -600,5 +601,112 @@ class TestSeqeunceOTelJobs:
 
         assert len(events) == 8
         assert all(isinstance(event, OTelEvent) for event in events)
+        assert all(count == 2 for count in job_id_count.values())
+        assert len(valid_event_ids) == 0
+
+    def test_otel_to_pv(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_yaml_config_dict: dict[str, Any],
+        sql_data_holder_with_otel_jobs: SQLDataHolder,
+        mock_yaml_config_string: str,
+        mock_temp_dir_with_json_files: Path,
+    ) -> None:
+        """Tests for the function otel_to_pv."""
+
+        # Test 1: Default parameters
+        def mock_fetch_data_holder(config: IngestDataConfig) -> SQLDataHolder:
+            return sql_data_holder_with_otel_jobs
+
+        ingest_data_config = IngestDataConfig(
+            data_sources=mock_yaml_config_dict["data_sources"],
+            data_holders=mock_yaml_config_dict["data_holders"],
+            ingest_data=IngestTypes(**mock_yaml_config_dict["ingest_data"]),
+        )
+        monkeypatch.setattr(
+            "tel2puml.otel_to_pv.sequence_otel_v2.fetch_data_holder",
+            mock_fetch_data_holder,
+        )
+
+        result = otel_to_pv(ingest_data_config)
+
+        events = []
+        valid_job_names = {"test_name"}
+        valid_event_ids = [f"{i}_{j}" for i in range(5) for j in range(2)]
+        valid_job_ids = {f"test_id_{i}" for i in range(5)}
+        job_id_count: dict[str, int] = {}
+        for job_name, pv_event_streams in result:
+            assert job_name in valid_job_names
+            for pv_event_gen in pv_event_streams:
+                for pv_event in pv_event_gen:
+                    job_id_count.setdefault(pv_event["jobId"], 0)
+                    job_id_count[pv_event["jobId"]] += 1
+                    events.append(pv_event)
+                    assert pv_event["eventId"] in valid_event_ids
+                    assert pv_event["jobId"] in valid_job_ids
+                    valid_event_ids.remove(pv_event["eventId"])
+
+        assert len(events) == 10
+        assert all(count == 2 for count in job_id_count.values())
+        assert len(valid_event_ids) == 0
+
+        # Test 2: ingest_data = True
+        config = self.get_ingest_config(
+            mock_yaml_config_string, mock_temp_dir_with_json_files
+        )
+        result = otel_to_pv(config, ingest_data=True)
+
+        events = []
+        valid_job_names = {"Backend TestJob", "Frontend TestJob"}
+        valid_job_ids = {
+            "0_trace_id_1 4.8",
+            "1_trace_id_1 4.8",
+            "0_trace_id_0 4.8",
+            "1_trace_id_0 4.8",
+        }
+        valid_event_ids = [
+            f"{i}_span_{j}_{k}"
+            for i in range(2)
+            for j in range(2)
+            for k in range(2)
+        ]
+        job_id_count = {}
+        for job_name, pv_event_streams in result:
+            assert job_name in valid_job_names
+            for pv_event_gen in pv_event_streams:
+                for pv_event in pv_event_gen:
+                    job_id_count.setdefault(pv_event["jobId"], 0)
+                    job_id_count[pv_event["jobId"]] += 1
+                    events.append(pv_event)
+                    assert pv_event["eventId"] in valid_event_ids
+                    assert pv_event["jobId"] in valid_job_ids
+                    valid_event_ids.remove(pv_event["eventId"])
+
+        assert len(events) == 8
+        assert all(count == 2 for count in job_id_count.values())
+        assert len(valid_event_ids) == 0
+
+        # Test 3: find_unique_graphs = True
+        result = otel_to_pv(ingest_data_config, find_unique_graphs=True)
+
+        events = []
+        valid_job_names = {"test_name"}
+        # job id test_id_0 is outside the config time buffer window, therefore
+        # it is not included, reducing total events streamed to 8
+        valid_event_ids = [f"{i}_{j}" for i in range(1, 5) for j in range(2)]
+        valid_job_ids = {f"test_id_{i}" for i in range(1, 5)}
+        job_id_count = {}
+        for job_name, pv_event_streams in result:
+            assert job_name in valid_job_names
+            for pv_event_gen in pv_event_streams:
+                for pv_event in pv_event_gen:
+                    job_id_count.setdefault(pv_event["jobId"], 0)
+                    job_id_count[pv_event["jobId"]] += 1
+                    events.append(pv_event)
+                    assert pv_event["eventId"] in valid_event_ids
+                    assert pv_event["jobId"] in valid_job_ids
+                    valid_event_ids.remove(pv_event["eventId"])
+
+        assert len(events) == 8
         assert all(count == 2 for count in job_id_count.values())
         assert len(valid_event_ids) == 0


### PR DESCRIPTION
This PR adds a function otel_to_pv that takes in the config, streams data from the data holder and converts OTelEvents to PVEvents.