### PR TITLE
143 option to map event type name to another name given children

### DIFF
--- a/tel2puml/otel_to_pv/config.py
+++ b/tel2puml/otel_to_pv/config.py
@@ -10,6 +10,7 @@ from typing import (
 from pydantic import BaseModel, ConfigDict as PYDConfigDict
 
 from .data_sources.data_sources_config import DataSources
+from .otel_to_pv_types import OTelEventTypeMap
 
 
 class SequenceModelConfig(BaseModel):
@@ -19,6 +20,7 @@ class SequenceModelConfig(BaseModel):
 
     async_event_groups: dict[str, dict[str, dict[str, str]]] = {}
     async_flag: bool = False
+    event_name_map_information: dict[str, dict[str, OTelEventTypeMap]] = {}
 
 
 class SQLDataHolderConfig(TypedDict):

--- a/tel2puml/otel_to_pv/otel_to_pv.py
+++ b/tel2puml/otel_to_pv/otel_to_pv.py
@@ -53,6 +53,8 @@ def otel_to_pv(
     job_name_group_streams = data_holder.stream_data(job_name_to_job_ids_map)
     # get the async event groups from the config
     sequencer_config = config.get("sequencer", SequenceModelConfig())
+    async_event_groups = sequencer_config.async_event_groups
+    event_name_map_information = sequencer_config.event_name_map_information
     return (
         (
             job_name,
@@ -60,7 +62,12 @@ def otel_to_pv(
                 job_id_streams,
                 async_flag=sequencer_config.async_flag,
                 event_to_async_group_map=(
-                    sequencer_config.async_event_groups.get(job_name, None)
+                    async_event_groups.get(job_name, None)
+                ),
+                event_types_map_information=(
+                    event_name_map_information.get(
+                        job_name, None
+                    )
                 ),
             ),
         )

--- a/tel2puml/otel_to_pv/otel_to_pv_types.py
+++ b/tel2puml/otel_to_pv/otel_to_pv_types.py
@@ -36,3 +36,9 @@ class OTelEvent(BaseModel):
     application_name: str
     parent_event_id: Optional[str]
     child_event_ids: Optional[list[str]] = None
+
+
+class OTelEventTypeMap(BaseModel):
+    """PyDantic type for OTel event type map."""
+    mapped_event_type: str
+    child_event_types: set[str]

--- a/tel2puml/otel_to_pv/sequence_otel.py
+++ b/tel2puml/otel_to_pv/sequence_otel.py
@@ -320,7 +320,7 @@ def sequence_otel_jobs(
 
 
 def sequence_otel_job_id_streams(
-    job_id_streams: Generator[Generator[OTelEvent, Any, None], Any, None],
+    job_id_streams: Iterable[Iterable[OTelEvent]],
     async_flag: bool = False,
     event_to_async_group_map: dict[str, dict[str, str]] | None = None,
     event_types_map_information: dict[str, OTelEventTypeMap] | None = None,
@@ -328,10 +328,9 @@ def sequence_otel_job_id_streams(
     """
     Sequence OTel events in multiple jobs.
 
-    :param job_id_streams: A generator of generators, where each inner
-    generator yields OTelEvent objects grouped by job ID.
-    :type job_id_streams: `Generator`[`Generator`[:class:`OTelEvent`, `Any`,
-    `None`], `Any`, `None`]
+    :param job_id_streams: An iterable of iterables, where each inner
+    iterable contains OTelEvent objects grouped by job ID.
+    :type job_id_streams: `Iterable`[`Iterable`[:class:`OTelEvent`]]
     :param async_flag: A flag indicating whether to sequence event groups
     asynchronously or not, defaults to False.
     :type async_flag: `bool`
@@ -356,15 +355,14 @@ def sequence_otel_job_id_streams(
 
 
 def job_ids_to_eventid_to_otelevent_map(
-    job_id_streams: Generator[Generator[OTelEvent, Any, None], Any, None],
+    job_id_streams: Iterable[Iterable[OTelEvent]],
 ) -> Generator[dict[str, OTelEvent], Any, None]:
     """
     Creates a mapping from event IDs to OTelEvent objects for each job.
 
-    :param job_id_streams: A generator of generators, where each inner
+    :param job_id_streams: A iterable of iterables, where each inner
     generator yields OTelEvent objects grouped by job ID.
-    :type job_id_streams: `Generator`[`Generator`[:class:`OTelEvent`,
-    `Any`, `None`], `Any`, `None`]
+    :type job_id_streams: `Iterable`[`Iterable`[:class:`OTelEvent`]]
     :return: A generator of dictionaries mapping event IDs to OTelEvent
     objects for each job.
     :rtype: `Generator`[`dict`[`str`, :class:`OTelEvent`], `Any`, `None`]

--- a/tel2puml/otel_to_pv/sequence_otel.py
+++ b/tel2puml/otel_to_pv/sequence_otel.py
@@ -245,6 +245,8 @@ def update_event_type_based_on_children(
     :type event_type_map_information: :class:`OTelEventTypeMap`
     :raises KeyError: If a child event ID is not found in the job.
     """
+    if otel_event.child_event_ids is None:
+        return
     for child_event_id in otel_event.child_event_ids:
         try:
             child_event = otel_events_job[child_event_id]

--- a/tests/tel2puml/otel_to_pv/test_config.py
+++ b/tests/tel2puml/otel_to_pv/test_config.py
@@ -96,7 +96,8 @@ def test_sequence_model_config() -> None:
                     "mapped_event_type": "test_event_type",
                     "child_event_types": ["event_type_2"]
                 },
-            }
+            },
+            "job_2": {}
         }
     )
     assert sequence_model_config.async_event_groups == {
@@ -113,7 +114,8 @@ def test_sequence_model_config() -> None:
                     mapped_event_type="test_event_type",
                     child_event_types=["event_type_2"]
             ),
-        }
+        },
+        "job_2": {}
     }
     # test incorrect usage possibilities for async_event_groups
     with pytest.raises(ValidationError):

--- a/tests/tel2puml/otel_to_pv/test_otel_to_pv_types.py
+++ b/tests/tel2puml/otel_to_pv/test_otel_to_pv_types.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from tel2puml.otel_to_pv.otel_to_pv_types import OTelEvent
+from tel2puml.otel_to_pv.otel_to_pv_types import OTelEvent, OTelEventTypeMap
 
 
 def test_otel_event() -> None:
@@ -63,3 +63,17 @@ def test_otel_event() -> None:
     }
     with pytest.raises(ValidationError):
         OTelEvent(**input_dict)
+
+
+def test_otel_event_type_map() -> None:
+    """Test OTelEventTypeMap."""
+    # test that setting with correct types works does not raise an error
+    input_dict = {
+        "mapped_event_type": "mapped_event_type",
+        "child_event_types": ["child_event_type"],
+    }
+    OTelEventTypeMap(**input_dict)
+    # test that setting with incorrect types raises a validation error
+    input_dict = {"mapped_event_type": 1, "child_event_types": 1}
+    with pytest.raises(ValidationError):
+        OTelEventTypeMap(**input_dict)

--- a/tests/tel2puml/otel_to_pv/test_otel_to_pv_types.py
+++ b/tests/tel2puml/otel_to_pv/test_otel_to_pv_types.py
@@ -68,12 +68,12 @@ def test_otel_event() -> None:
 def test_otel_event_type_map() -> None:
     """Test OTelEventTypeMap."""
     # test that setting with correct types works does not raise an error
-    input_dict = {
+    input_dict_1 = {
         "mapped_event_type": "mapped_event_type",
         "child_event_types": ["child_event_type"],
     }
-    OTelEventTypeMap(**input_dict)
+    OTelEventTypeMap(**input_dict_1)
     # test that setting with incorrect types raises a validation error
-    input_dict = {"mapped_event_type": 1, "child_event_types": 1}
+    input_dict_2 = {"mapped_event_type": 1, "child_event_types": 1}
     with pytest.raises(ValidationError):
-        OTelEventTypeMap(**input_dict)
+        OTelEventTypeMap(**input_dict_2)

--- a/tests/tel2puml/otel_to_pv/test_sequence_otel.py
+++ b/tests/tel2puml/otel_to_pv/test_sequence_otel.py
@@ -448,9 +448,9 @@ class TestSeqeunceOTelJobs:
         )
         assert len(jobs) == 1
         job = jobs[0]
-        events = {pv_event["eventId"]: pv_event for pv_event in job}
-        assert events["0_0"]["eventType"] == "test_event_type"
-        assert events["0_1"]["eventType"] == "event_type_1"
+        pv_events_dict = {pv_event["eventId"]: pv_event for pv_event in job}
+        assert pv_events_dict["0_0"]["eventType"] == "test_event_type"
+        assert pv_events_dict["0_1"]["eventType"] == "event_type_1"
 
     def test_sequence_otel_job_id_streams(
         self, event_to_async_group_map: dict[str, dict[str, str]],
@@ -525,9 +525,9 @@ class TestSeqeunceOTelJobs:
         )
         assert len(jobs) == 1
         job = jobs[0]
-        events = {pv_event["eventId"]: pv_event for pv_event in job}
-        assert events["0_0"]["eventType"] == "test_event_type"
-        assert events["0_1"]["eventType"] == "event_type_1"
+        pv_events = {pv_event["eventId"]: pv_event for pv_event in job}
+        assert pv_events["0_0"]["eventType"] == "test_event_type"
+        assert pv_events["0_1"]["eventType"] == "event_type_1"
 
     def test_job_ids_to_eventid_to_otelevent_map(self) -> None:
         """Tests for the function job_ids_to_eventid_to_otelevent_map"""

--- a/tests/tel2puml/otel_to_pv/test_sequence_otel.py
+++ b/tests/tel2puml/otel_to_pv/test_sequence_otel.py
@@ -531,14 +531,6 @@ class TestSeqeunceOTelJobs:
 
     def test_job_ids_to_eventid_to_otelevent_map(self) -> None:
         """Tests for the function job_ids_to_eventid_to_otelevent_map"""
-
-        def job_id_streams() -> (
-            Generator[Generator[OTelEvent, None, None], None, None]
-        ):
-            """Create a generator of generators of OTelEvents"""
-            event_group = [event for event in events.values()]
-            yield (event for event in event_group)
-
         events = self.events_with_root()
 
         expected_mappings = []
@@ -546,7 +538,9 @@ class TestSeqeunceOTelJobs:
             {event.event_id: event for event in events.values()}
         )
 
-        event_dict_gen = job_ids_to_eventid_to_otelevent_map(job_id_streams())
+        event_dict_gen = job_ids_to_eventid_to_otelevent_map(
+            [events.values()]
+        )
         actual_mappings = list(event_dict_gen)
 
         assert len(actual_mappings) == len(expected_mappings)

--- a/tests/tel2puml/otel_to_pv/test_sequence_otel.py
+++ b/tests/tel2puml/otel_to_pv/test_sequence_otel.py
@@ -453,7 +453,8 @@ class TestSeqeunceOTelJobs:
         assert events["0_1"]["eventType"] == "event_type_1"
 
     def test_sequence_otel_job_id_streams(
-        self, event_to_async_group_map: dict[str, dict[str, str]]
+        self, event_to_async_group_map: dict[str, dict[str, str]],
+        otel_jobs: dict[str, list[OTelEvent]],
     ) -> None:
         """Tests for the function sequence_otel_job_id_streams"""
 
@@ -515,6 +516,18 @@ class TestSeqeunceOTelJobs:
         assert self.sort_pv_events(actual_pv_events) == self.sort_pv_events(
             expected_pv_events
         )
+        # test case with event_types_map_information
+        jobs = list(
+            sequence_otel_job_id_streams(
+                [self.otel_event_job(otel_jobs).values()],
+                event_types_map_information=self.event_types_map(),
+            )
+        )
+        assert len(jobs) == 1
+        job = jobs[0]
+        events = {pv_event["eventId"]: pv_event for pv_event in job}
+        assert events["0_0"]["eventType"] == "test_event_type"
+        assert events["0_1"]["eventType"] == "event_type_1"
 
     def test_job_ids_to_eventid_to_otelevent_map(self) -> None:
         """Tests for the function job_ids_to_eventid_to_otelevent_map"""


### PR DESCRIPTION
PR to add functionality to change OTelEvents ingested based on their children.

- Updates config to provide information on event types that need changing
- Updates otel_to_pv to use the config provided
- Updates sequencer to use event types along with mapping information