### PR TITLE
152 fix data holder node relation addition

### DIFF
--- a/tel2puml/otel_to_pv/data_holders/sql_data_holder/sql_dataholder.py
+++ b/tel2puml/otel_to_pv/data_holders/sql_data_holder/sql_dataholder.py
@@ -133,15 +133,13 @@ class SQLDataHolder(DataHolder):
         :param otel_event: An OTelEvent object
         :type otel_event: :class: `OTelEvent`
         """
-
-        if otel_event.child_event_ids:
-            for child_event_id in otel_event.child_event_ids:
-                self.node_relationships_to_save.append(
-                    {
-                        "parent_id": otel_event.event_id,
-                        "child_id": child_event_id,
-                    }
-                )
+        if otel_event.parent_event_id:
+            self.node_relationships_to_save.append(
+                {
+                    "parent_id": otel_event.parent_event_id,
+                    "child_id": otel_event.event_id,
+                }
+            )
 
     @staticmethod
     def convert_otel_event_to_node_model(otel_event: OTelEvent) -> NodeModel:

--- a/tests/tel2puml/otel_to_pv/data_holders/sql_data_holder/test_sql_dataholder.py
+++ b/tests/tel2puml/otel_to_pv/data_holders/sql_data_holder/test_sql_dataholder.py
@@ -122,15 +122,17 @@ class TestSQLDataHolder:
         mock_sql_config: SQLDataHolderConfig, mock_otel_event: OTelEvent
     ) -> None:
         """Tests add_node_relations method."""
-
         holder = SQLDataHolder(mock_sql_config)
         holder.add_node_relations(mock_otel_event)
-
+        assert len(holder.node_relationships_to_save) == 1
+        mock_otel_event.event_id = "876"
+        mock_otel_event.parent_event_id = "987"
+        holder.add_node_relations(mock_otel_event)
         assert len(holder.node_relationships_to_save) == 2
-        assert holder.node_relationships_to_save[0]["parent_id"] == "456"
-        assert holder.node_relationships_to_save[0]["child_id"] == "101"
-        assert holder.node_relationships_to_save[1]["parent_id"] == "456"
-        assert holder.node_relationships_to_save[1]["child_id"] == "102"
+        assert holder.node_relationships_to_save[0]["parent_id"] == "789"
+        assert holder.node_relationships_to_save[0]["child_id"] == "456"
+        assert holder.node_relationships_to_save[1]["parent_id"] == "987"
+        assert holder.node_relationships_to_save[1]["child_id"] == "876"
 
     @staticmethod
     def test_save_data(
@@ -353,8 +355,10 @@ class TestSQLDataHolder:
         # Check if relationships were saved
         relationships = holder.session.query(NODE_ASSOCIATION).all()
         assert len(relationships) == 2
-        assert relationships[0].parent_id == "456"
-        assert relationships[0].child_id in ["101", "102"]
+        assert relationships[0].parent_id == "789"
+        assert relationships[0].child_id == "456"
+        assert relationships[1].parent_id == "456"
+        assert relationships[1].child_id == "101"
 
     @staticmethod
     def test_node_to_otel_event(


### PR DESCRIPTION
Fixes bug in which child event ids (not a required field) were being used to update node relations table. this has been fixed in this PR to use only parent_event_id field that should always be present.