### PR TITLE
158-function-to-remove-jobs-with-disconnected-spans

### DIFF
--- a/tel2puml/otel_to_pv/data_holders/base.py
+++ b/tel2puml/otel_to_pv/data_holders/base.py
@@ -130,6 +130,13 @@ class DataHolder(ABC):
         of the root span.
         """
 
+    @abstractmethod
+    def remove_disconnected_spans(self) -> None:
+        """Abstract method to remove spans associated with job ids that contain
+        disconnected spans.
+        """
+        pass
+
 
 def get_time_window(
     time_buffer: int, data_holder: DataHolder

--- a/tel2puml/otel_to_pv/data_holders/base.py
+++ b/tel2puml/otel_to_pv/data_holders/base.py
@@ -131,7 +131,7 @@ class DataHolder(ABC):
         """
 
     @abstractmethod
-    def remove_disconnected_spans(self) -> None:
+    def remove_inconsistent_jobs(self) -> None:
         """Abstract method to remove spans associated with job ids that contain
         disconnected spans.
         """

--- a/tel2puml/otel_to_pv/data_holders/sql_data_holder/sql_dataholder.py
+++ b/tel2puml/otel_to_pv/data_holders/sql_data_holder/sql_dataholder.py
@@ -325,7 +325,7 @@ class SQLDataHolder(DataHolder):
             session.execute(stmt_2)
             session.commit()
 
-    def remove_disconnected_spans(self) -> None:
+    def remove_inconsistent_jobs(self) -> None:
         """Method to remove spans associated with job ids that contain
         disconnected spans.
         """
@@ -355,8 +355,11 @@ class SQLDataHolder(DataHolder):
                 .distinct()
             )
             stmt_3 = sa.delete(NodeModel).where(NodeModel.job_id.in_(stmt_2))
-            session.execute(stmt_3)
+            res = session.execute(stmt_3)
             session.commit()
+            logging.getLogger().info(
+                f"Number of nodes with inconsistent jobs: {res.rowcount}"
+            )
 
 
 def intialise_temp_table_for_root_nodes(

--- a/tel2puml/otel_to_pv/data_holders/sql_data_holder/sql_dataholder.py
+++ b/tel2puml/otel_to_pv/data_holders/sql_data_holder/sql_dataholder.py
@@ -6,7 +6,7 @@ from itertools import groupby
 import logging
 
 import sqlalchemy as sa
-from sqlalchemy import create_engine, insert, or_
+from sqlalchemy import create_engine, insert, or_, not_
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import OperationalError, IntegrityError
 from sqlalchemy.orm.exc import DetachedInstanceError
@@ -317,14 +317,45 @@ class SQLDataHolder(DataHolder):
             stmt_1 = sa.select(NodeModel.job_id, NodeModel.job_name).filter(
                 NodeModel.parent_event_id.is_(None)
             )
-            stmt_2 = sa.update(NodeModel).where(
-                NodeModel.job_id == stmt_1.c.job_id
-            ).values(
-                job_name=stmt_1.c.job_name
+            stmt_2 = (
+                sa.update(NodeModel)
+                .where(NodeModel.job_id == stmt_1.c.job_id)
+                .values(job_name=stmt_1.c.job_name)
             )
-            session.execute(
-                stmt_2
+            session.execute(stmt_2)
+            session.commit()
+
+    def remove_disconnected_spans(self) -> None:
+        """Method to remove spans associated with job ids that contain
+        disconnected spans.
+        """
+        with self.session as session:
+            # Finds all parent_id within node_association that does not exist
+            # within NodeModel table
+            stmt_1 = (
+                sa.select(NODE_ASSOCIATION.c.parent_id)
+                .where(
+                    not_(
+                        sa.exists().where(
+                            NODE_ASSOCIATION.c.parent_id == NodeModel.event_id
+                        )
+                    )
+                )
+                .distinct()
+                .subquery()
             )
+            # Finds all job_ids assoication with stmt_1
+            stmt_2 = (
+                sa.select(NodeModel.job_id)
+                .join(
+                    NODE_ASSOCIATION,
+                    NODE_ASSOCIATION.c.child_id == NodeModel.event_id,
+                )
+                .where(NODE_ASSOCIATION.c.parent_id.in_(sa.select(stmt_1)))
+                .distinct()
+            )
+            stmt_3 = sa.delete(NodeModel).where(NodeModel.job_id.in_(stmt_2))
+            session.execute(stmt_3)
             session.commit()
 
 

--- a/tel2puml/otel_to_pv/otel_to_pv.py
+++ b/tel2puml/otel_to_pv/otel_to_pv.py
@@ -45,7 +45,7 @@ def otel_to_pv(
     else:
         data_holder = fetch_data_holder(config)
     # validate spans
-    data_holder.remove_disconnected_spans()
+    data_holder.remove_inconsistent_jobs()
     # make sure job names are consistent in traces
     data_holder.update_job_names_by_root_span()
     # find unique graphs if required

--- a/tel2puml/otel_to_pv/otel_to_pv.py
+++ b/tel2puml/otel_to_pv/otel_to_pv.py
@@ -44,6 +44,8 @@ def otel_to_pv(
         data_holder = ingest_data_into_dataholder(config)
     else:
         data_holder = fetch_data_holder(config)
+    # validate spans
+    data_holder.remove_disconnected_spans()
     # make sure job names are consistent in traces
     data_holder.update_job_names_by_root_span()
     # find unique graphs if required

--- a/tests/tel2puml/otel_to_pv/data_holders/sql_data_holder/test_sql_dataholder.py
+++ b/tests/tel2puml/otel_to_pv/data_holders/sql_data_holder/test_sql_dataholder.py
@@ -417,10 +417,12 @@ class TestSQLDataHolder:
         unique_job_ids_per_job_name = (
             sql_data_holder_extended.find_unique_graphs()
         )
-        assert set(unique_job_ids_per_job_name.keys()) == set([
-            "test_name_2",
-            "test_name",
-        ])
+        assert set(unique_job_ids_per_job_name.keys()) == set(
+            [
+                "test_name_2",
+                "test_name",
+            ]
+        )
         assert unique_job_ids_per_job_name["test_name"] == {
             "test_id_1",
         }
@@ -430,7 +432,7 @@ class TestSQLDataHolder:
 
     @staticmethod
     def test_update_job_names_by_root_span(
-        sql_data_holder_otel_jobs_with_job_names_on_root: SQLDataHolder
+        sql_data_holder_otel_jobs_with_job_names_on_root: SQLDataHolder,
     ) -> None:
         """Tests update_job_names_by_root_span method."""
         expected_event_id_to_job_name_and_job_id = {
@@ -439,11 +441,11 @@ class TestSQLDataHolder:
             for j in range(3)
         }
         expected_event_id_to_job_name_and_job_id["5_0"] = (
-            "test_name_5", "test_id_5"
+            "test_name_5",
+            "test_id_5",
         )
         (
-            sql_data_holder_otel_jobs_with_job_names_on_root
-            .update_job_names_by_root_span()
+            sql_data_holder_otel_jobs_with_job_names_on_root.update_job_names_by_root_span()
         )
         with sql_data_holder_otel_jobs_with_job_names_on_root.session as (
             session
@@ -731,13 +733,15 @@ def test_find_unique_graphs(
     unique_job_ids_per_job_name = find_unique_graphs(
         1, 2, sql_data_holder_extended
     )
-    assert set(unique_job_ids_per_job_name.keys()) == set([
-        "test_name_2",
-        "test_name",
-    ])
+    assert set(unique_job_ids_per_job_name.keys()) == set(
+        [
+            "test_name_2",
+            "test_name",
+        ]
+    )
     assert unique_job_ids_per_job_name["test_name"] == {
-            "test_id_1",
-        }
+        "test_id_1",
+    }
     assert unique_job_ids_per_job_name["test_name_2"] == {
         str(f"{i}{0}") for i in range(5)
     }
@@ -948,3 +952,29 @@ def test_stream_job_name_batches(
         all_events = list(otel_event_gen)
 
     assert len(all_events) == 0
+
+
+def test_remove_disconnected_spans(
+    sql_data_holder_with_otel_jobs: SQLDataHolder,
+) -> None:
+    """Tests the method remove_disconnected_spans"""
+    sql_data_holder = sql_data_holder_with_otel_jobs
+    with sql_data_holder.session as session:
+        nodes = session.query(NodeModel).all()
+        assert len(nodes) == 10
+        assert "test_id_0" in {node.job_id for node in nodes}
+
+        # Delete the root span, creating disconnected data
+        session.execute(
+            sa.delete(NodeModel).where(NodeModel.event_id == "0_0")
+        )
+        session.commit()
+        assert session.query(NodeModel).count() == 9
+
+    sql_data_holder.remove_disconnected_spans()
+
+    with sql_data_holder.session as session:
+        nodes = session.query(NodeModel).all()
+
+    assert len(nodes) == 8
+    assert "test_id_0" not in {node.job_id for node in nodes}

--- a/tests/tel2puml/otel_to_pv/data_holders/sql_data_holder/test_sql_dataholder.py
+++ b/tests/tel2puml/otel_to_pv/data_holders/sql_data_holder/test_sql_dataholder.py
@@ -445,7 +445,8 @@ class TestSQLDataHolder:
             "test_id_5",
         )
         (
-            sql_data_holder_otel_jobs_with_job_names_on_root.update_job_names_by_root_span()
+            sql_data_holder_otel_jobs_with_job_names_on_root
+            .update_job_names_by_root_span()
         )
         with sql_data_holder_otel_jobs_with_job_names_on_root.session as (
             session

--- a/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
+++ b/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+import sqlalchemy as sa
 from pytest import MonkeyPatch
 
 from tel2puml.otel_to_pv.otel_to_pv import otel_to_pv
@@ -16,10 +17,14 @@ from tel2puml.otel_to_pv.config import (
     SequenceModelConfig,
 )
 from tel2puml.otel_to_pv.otel_to_pv_types import OTelEventTypeMap
+from tel2puml.otel_to_pv.data_holders.sql_data_holder.data_model import (
+    NodeModel,
+)
 
 
 class TestOtelToPV:
     """Tests for the otel_to_pv function."""
+
     def get_ingest_config(
         self, config_yaml: str, new_dirpath: Path
     ) -> IngestDataConfig:
@@ -218,3 +223,46 @@ class TestOtelToPV:
                         assert pv_event["eventType"] == "test_event_type"
                     else:
                         assert pv_event["eventType"] == "event_type_1"
+
+        # Test 7: Remove disconnected spans
+        def mock_fetch_data_holder_disconnected_spans(
+            config: IngestDataConfig,
+        ) -> SQLDataHolder:
+            """Remove root span to create disconnected data within NodeModel
+            table"""
+            sql_data_holder = sql_data_holder_with_otel_jobs
+            with sql_data_holder.session as session:
+                stmt = sa.delete(NodeModel).where(NodeModel.event_id == "0_0")
+                session.execute(stmt)
+                session.commit()
+            return sql_data_holder
+
+        ingest_data_config = IngestDataConfig(
+            data_sources=mock_yaml_config_dict["data_sources"],
+            data_holders=mock_yaml_config_dict["data_holders"],
+            ingest_data=IngestTypes(**mock_yaml_config_dict["ingest_data"]),
+        )
+        monkeypatch.setattr(
+            "tel2puml.otel_to_pv.otel_to_pv.fetch_data_holder",
+            mock_fetch_data_holder_disconnected_spans,
+        )
+
+        result = otel_to_pv(ingest_data_config)
+        events = []
+        valid_event_ids = [f"{i}_{j}" for i in range(1, 5) for j in range(2)]
+        valid_job_ids = {f"test_id_{i}" for i in range(1, 5)}
+        job_id_count: dict[str, int] = {}
+        for job_name, pv_event_streams in result:
+            assert job_name == "test_name"
+            for pv_event_gen in pv_event_streams:
+                for pv_event in pv_event_gen:
+                    job_id_count.setdefault(pv_event["jobId"], 0)
+                    job_id_count[pv_event["jobId"]] += 1
+                    events.append(pv_event)
+                    assert pv_event["eventId"] in valid_event_ids
+                    assert pv_event["jobId"] in valid_job_ids
+                    valid_event_ids.remove(pv_event["eventId"])
+
+        assert len(events) == 8
+        assert all(job_id_count[job_id] == 2 for job_id in valid_job_ids)
+        assert len(valid_event_ids) == 0

--- a/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
+++ b/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
@@ -251,7 +251,7 @@ class TestOtelToPV:
         events = []
         valid_event_ids = [f"{i}_{j}" for i in range(1, 5) for j in range(2)]
         valid_job_ids = {f"test_id_{i}" for i in range(1, 5)}
-        job_id_count: dict[str, int] = {}
+        job_id_count = {}
         for job_name, pv_event_streams in result:
             assert job_name == "test_name"
             for pv_event_gen in pv_event_streams:


### PR DESCRIPTION
This PR adds a method to the DataHolder and SQLDataholder class to remove spans associated with job ids that have disconnected spans.