### PR TITLE
166 add logging for validation fails for otel events

### DIFF
--- a/tel2puml/otel_to_pv/data_sources/json_data_source/json_datasource.py
+++ b/tel2puml/otel_to_pv/data_sources/json_data_source/json_datasource.py
@@ -123,9 +123,12 @@ class JSONDataSource(OTELDataSource):
                     except ValidationError as e:
                         self.event_error_pbar.update(1)
                         LOGGER.warning(
-                            f"Error parsing file: {filepath}\n"
-                            f"Error: {e}\n"
-                            f"Record: {record}"
+                            f"Error coercing data in file: {filepath}\n"
+                            f"Validation Error: {e}\n"
+                            f"Record: {record}\n"
+                            "Skipping record - if this is a persistent error, "
+                            "please check the field mapping or jq query in the"
+                            " input config.yaml."
                         )
 
     def __next__(self) -> OTelEvent:

--- a/tel2puml/otel_to_pv/data_sources/json_data_source/json_datasource.py
+++ b/tel2puml/otel_to_pv/data_sources/json_data_source/json_datasource.py
@@ -3,6 +3,10 @@
 import os
 from typing import Iterator
 import json
+from logging import getLogger
+
+from tqdm import tqdm
+from pydantic import ValidationError
 
 from tel2puml.otel_to_pv.otel_to_pv_types import OTelEvent
 from ..base import OTELDataSource
@@ -11,6 +15,9 @@ from .json_jq_converter import (
     field_mapping_to_compiled_jq,
 )
 from .json_config import JSONDataSourceConfig
+
+
+LOGGER = getLogger(__name__)
 
 
 class JSONDataSource(OTELDataSource):
@@ -33,6 +40,17 @@ class JSONDataSource(OTELDataSource):
         self.file_list = self.get_file_list()
         self.compiled_jq = field_mapping_to_compiled_jq(
             self.config["field_mapping"]
+        )
+        self.file_pbar = tqdm(
+            total=len(self.file_list),
+            desc="Ingesting JSON files",
+            unit="file",
+            position=0,
+        )
+        self.event_error_pbar = tqdm(
+            desc="Events with errors",
+            unit="event",
+            position=1,
         )
 
     def set_dirpath(self) -> str | None:
@@ -100,7 +118,15 @@ class JSONDataSource(OTELDataSource):
                 for record in generate_records_from_compiled_jq(
                     data, self.compiled_jq
                 ):
-                    yield OTelEvent(**record)
+                    try:
+                        yield OTelEvent(**record)
+                    except ValidationError as e:
+                        self.event_error_pbar.update(1)
+                        LOGGER.warning(
+                            f"Error parsing file: {filepath}\n"
+                            f"Error: {e}\n"
+                            f"Record: {record}"
+                        )
 
     def __next__(self) -> OTelEvent:
         """Returns the next OTelEvent in the sequence
@@ -110,6 +136,7 @@ class JSONDataSource(OTELDataSource):
         """
         while self.current_file_index < len(self.file_list):
             if self.current_parser is None:
+                self.file_pbar.update(1)
                 self.current_parser = self.parse_json_stream(
                     self.file_list[self.current_file_index]
                 )
@@ -118,5 +145,6 @@ class JSONDataSource(OTELDataSource):
             except StopIteration:
                 self.current_file_index += 1
                 self.current_parser = None
-
+        self.file_pbar.close()
+        self.event_error_pbar.close()
         raise StopIteration

--- a/tel2puml/otel_to_pv/data_sources/json_data_source/json_jq_converter.py
+++ b/tel2puml/otel_to_pv/data_sources/json_data_source/json_jq_converter.py
@@ -237,6 +237,8 @@ def handle_string_joined_variables_jq_query(
     :raises ValueError: If there are no priority variables in one of the nested
     lists
     """
+    if len(variables) == 0:
+        return ""
     join_variables_output: list[str] = []
     for priority_variables in variables:
         if len(priority_variables) == 0:
@@ -246,7 +248,11 @@ def handle_string_joined_variables_jq_query(
             + " // ".join(priority_variables)
             + " | (if . == null then null else (. | tostring) end))"
         )
-    return ' + "_" + '.join(join_variables_output)
+    return (
+        f"([{','.join(join_variables_output)}] |"
+        " if any(. == null) then null else "
+        f'join("_") end)'
+    )
 
 
 def handle_array_joined_variables_jq_query(

--- a/tests/tel2puml/otel_to_pv/data_sources/json_data_source/conftest.py
+++ b/tests/tel2puml/otel_to_pv/data_sources/json_data_source/conftest.py
@@ -158,9 +158,9 @@ def field_spec_with_variables_1_expected_jq() -> str:
         " catch null) as"
         " $out0concat00"
         " | (try $var2.third_1.third_2 catch null) as $out0concat10"
-        " | (($out0concat00 | (if . == null then null else (. | tostring) "
-        'end)) + "_" + ($out0concat10 | (if . == null then null else (. | '
-        "tostring) end)))"
+        " | (([($out0concat00 | (if . == null then null else (. | tostring) "
+        'end)),($out0concat10 | (if . == null then null else (. | '
+        'tostring) end))] | if any(. == null) then null else join("_") end))'
         " as"
         " $out0"
     )
@@ -172,9 +172,9 @@ def field_spec_with_variables_2_expected_jq() -> str:
     return (
         " | (try $var0.first.second.third catch null) as $out1concat00"
         " | (try $var0.first.second.third catch null) as $out1concat10"
-        " | (($out1concat00 | (if . == null then null else (. | tostring) "
-        'end)) + "_" + ($out1concat10 | (if . == null then null else (. | '
-        "tostring) end)))"
+        " | (([($out1concat00 | (if . == null then null else (. | tostring) "
+        'end)),($out1concat10 | (if . == null then null else (. | '
+        'tostring) end))] | if any(. == null) then null else join("_") end))'
         " as"
         " $out1"
     )
@@ -186,9 +186,9 @@ def field_spec_with_variables_3_expected_jq() -> str:
     return (
         " | (try $var3.fifth catch null) as $out2concat00"
         " | (try $var3.fifth catch null) as $out2concat10"
-        " | (($out2concat00 | (if . == null then null else (. | tostring) "
-        'end)) + "_" + ($out2concat10 | (if . == null then null else (. | '
-        "tostring) end)))"
+        " | (([($out2concat00 | (if . == null then null else (. | tostring) "
+        'end)),($out2concat10 | (if . == null then null else (. | '
+        'tostring) end))] | if any(. == null) then null else join("_") end))'
         " as"
         " $out2"
     )
@@ -203,8 +203,9 @@ def field_spec_with_variables_4_expected_jq() -> str:
         " catch null) as"
         " $out3concat00"
         " | (try $var2.third_1.third_2 catch null) as $out3concat01"
-        " | (($out3concat00 // $out3concat01 | (if . == null then null else "
-        "(. | tostring) end)))"
+        " | (([($out3concat00 // $out3concat01 | (if . == null then null else "
+        '(. | tostring) end))] | if any(. == null) then null else join("_") '
+        "end))"
         " as"
         " $out3"
     )

--- a/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_datasource.py
+++ b/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_datasource.py
@@ -236,9 +236,10 @@ class TestJSONDataSource:
                 otel_event = next(otel_events)
             assert (
                 "tel2puml.otel_to_pv.data_sources.json_data_source."
-                "json_datasource:json_datasource.py:125 Error parsing file: "
+                "json_datasource:json_datasource.py:125 Error coercing data in"
+                " file: "
                 "/mock/dir/file1.json\n"
-                "Error: 6 validation errors for OTelEvent\n"
+                "Validation Error: 6 validation errors for OTelEvent\n"
                 "job_name\n"
                 "  Input should be a valid string [type=string_type, "
                 "input_value=None, input_type=NoneType]\n"
@@ -273,7 +274,10 @@ class TestJSONDataSource:
                 "'event_type': None, 'event_id': 'span001', "
                 "'start_timestamp': None, 'end_timestamp': None, "
                 "'application_name': None, 'parent_event_id': None, "
-                "'child_event_ids': None}"
+                "'child_event_ids': None}\n"
+                "Skipping record - if this is a persistent error, "
+                "please check the field mapping or jq query in the"
+                " input config.yaml."
             ) in caplog.text
 
     @staticmethod

--- a/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_datasource.py
+++ b/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_datasource.py
@@ -1,12 +1,14 @@
 """Tests for otel_data_source module."""
+
 import json
 import os
 import shutil
-from typing import Literal
+from typing import Literal, Any
+from logging import WARNING
 
 import yaml
 import pytest
-from pytest import FixtureRequest
+from pytest import FixtureRequest, LogCaptureFixture
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
@@ -192,6 +194,90 @@ class TestJSONDataSource:
 
     @staticmethod
     @pytest.mark.usefixtures("mock_path_exists", "mock_filepath_in_dir")
+    def test_parse_json_stream(
+        mock_yaml_config_dict: IngestDataConfig,
+        mock_json_data: dict[str, Any],
+        caplog: LogCaptureFixture,
+    ) -> None:
+        """Tests the parse_json_stream method."""
+        mock_file_content = json.dumps(mock_json_data).encode("utf-8")
+        with patch("builtins.open", mock_open(read_data=mock_file_content)):
+            json_data_source = JSONDataSource(
+                mock_yaml_config_dict["data_sources"]["json"]
+            )
+            otel_events = json_data_source.parse_json_stream(
+                "/mock/dir/file1.json"
+            )
+            otel_event = next(otel_events)
+            assert otel_event.job_name == "Frontend_TestJob"
+            assert otel_event.job_id == "trace001_4.8"
+            assert otel_event.event_id == "span001"
+            assert otel_event.event_type == "com.T2h.366Yx_500"
+            assert otel_event.application_name == "Processor_1.0"
+            assert otel_event.start_timestamp == 1723544132228102912
+            assert otel_event.end_timestamp == 1723544132228219285
+            assert otel_event.parent_event_id is None
+            assert otel_event.child_event_ids == ["child1", "child2"]
+        # test case with a validation error
+        json_data = {"resource_spans": [
+            {"scope_spans": [{"spans": [{"span_id": "span001"}]}]}
+        ]}
+        mock_file_content = json.dumps(json_data).encode("utf-8")
+        with patch("builtins.open", mock_open(read_data=mock_file_content)):
+            json_data_source = JSONDataSource(
+                mock_yaml_config_dict["data_sources"]["json"]
+            )
+            caplog.clear()
+            caplog.set_level(WARNING)
+            otel_events = json_data_source.parse_json_stream(
+                "/mock/dir/file1.json"
+            )
+            with pytest.raises(StopIteration):
+                otel_event = next(otel_events)
+            assert (
+                "tel2puml.otel_to_pv.data_sources.json_data_source."
+                "json_datasource:json_datasource.py:125 Error parsing file: "
+                "/mock/dir/file1.json\n"
+                "Error: 6 validation errors for OTelEvent\n"
+                "job_name\n"
+                "  Input should be a valid string [type=string_type, "
+                "input_value=None, input_type=NoneType]\n"
+                "    For further information visit "
+                "https://errors.pydantic.dev/2.9/v/string_type\n"
+                "job_id\n"
+                "  Input should be a valid string [type=string_type, "
+                "input_value=None, input_type=NoneType]\n"
+                "    For further information visit "
+                "https://errors.pydantic.dev/2.9/v/string_type\n"
+                "event_type\n"
+                "  Input should be a valid string [type=string_type, "
+                "input_value=None, input_type=NoneType]\n"
+                "    For further information visit "
+                "https://errors.pydantic.dev/2.9/v/string_type\n"
+                "start_timestamp\n"
+                "  Input should be a valid integer [type=int_type, "
+                "input_value=None, input_type=NoneType]\n"
+                "    For further information visit "
+                "https://errors.pydantic.dev/2.9/v/int_type\n"
+                "end_timestamp\n"
+                "  Input should be a valid integer [type=int_type, "
+                "input_value=None, input_type=NoneType]\n"
+                "    For further information visit "
+                "https://errors.pydantic.dev/2.9/v/int_type\n"
+                "application_name\n"
+                "  Input should be a valid string [type=string_type, "
+                "input_value=None, input_type=NoneType]\n"
+                "    For further information visit "
+                "https://errors.pydantic.dev/2.9/v/string_type\n"
+                "Record: {'job_name': None, 'job_id': None, "
+                "'event_type': None, 'event_id': 'span001', "
+                "'start_timestamp': None, 'end_timestamp': None, "
+                "'application_name': None, 'parent_event_id': None, "
+                "'child_event_ids': None}"
+            ) in caplog.text
+
+    @staticmethod
+    @pytest.mark.usefixtures("mock_path_exists", "mock_filepath_in_dir")
     @pytest.mark.parametrize(
         "mock_data, mock_yaml_config",
         [
@@ -215,7 +301,8 @@ class TestJSONDataSource:
             request.getfixturevalue(mock_data)
         ).encode("utf-8")
         mock_file_content = (
-            mock_file_content[:1] + b'"injected_error": "\x1b", '
+            mock_file_content[:1]
+            + b'"injected_error": "\x1b", '
             + mock_file_content[1:]
         )
         mock_yaml_config_dict = request.getfixturevalue(mock_yaml_config)
@@ -239,8 +326,7 @@ class TestJSONDataSource:
                 otel_events.append(data)
 
         def check_otel_events(
-            otel_events: list[OTelEvent],
-            n_check: Literal[2, 4]
+            otel_events: list[OTelEvent], n_check: Literal[2, 4]
         ) -> None:
             """Check the otel events."""
             otel_event = otel_events[0]

--- a/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_jq_converter.py
+++ b/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_jq_converter.py
@@ -303,15 +303,18 @@ class TestFieldMappingToCompiledJQ:
         # test case with one variable
         assert handle_string_joined_variables_jq_query(
             [["x"]]
-        ) == "(x | (if . == null then null else (. | tostring) end))"
+        ) == (
+            '([(x | (if . == null then null else (. | tostring) end))] | if'
+            ' any(. == null) then null else join("_") end)'
+        )
         # test case with multiple variables with single and multiple priority
         # variables
         assert handle_string_joined_variables_jq_query(
             [["x", "y"], ["z"]]
         ) == (
-            '(x // y | (if . == null then null else (. | tostring) end))'
-            ' + "_" + '
-            '(z | (if . == null then null else (. | tostring) end))'
+            '([(x // y | (if . == null then null else (. | tostring) end)),'
+            '(z | (if . == null then null else (. | tostring) end))]'
+            ' | if any(. == null) then null else join("_") end)'
         )
 
     @staticmethod


### PR DESCRIPTION
This PR introduces functionality that skips over validation errors but reports them in logging. 

Also adds a pbar for:

- number of files processed
- number of validation errors seen