### PR TITLE
169 update otel to puml with save_events

### DIFF
--- a/tel2puml/__main__.py
+++ b/tel2puml/__main__.py
@@ -198,6 +198,7 @@ def generate_component_options(
                 generate_config(str(otel_to_pv_obj.config_file))
             ),
             ingest_data=otel_to_pv_obj.ingest_data,
+            save_events=otel_to_pv_obj.save_events
         )
     elif command == "pv2puml":
         pv_to_puml_obj = PvToPumlArgs(**args_dict)

--- a/tel2puml/__main__.py
+++ b/tel2puml/__main__.py
@@ -198,7 +198,8 @@ def generate_component_options(
                 generate_config(str(otel_to_pv_obj.config_file))
             ),
             ingest_data=otel_to_pv_obj.ingest_data,
-            save_events=otel_to_pv_obj.save_events
+            save_events=otel_to_pv_obj.save_events,
+            find_unique_graphs=otel_to_pv_obj.find_unique_graphs,
         )
     elif command == "pv2puml":
         pv_to_puml_obj = PvToPumlArgs(**args_dict)

--- a/tel2puml/otel_to_puml.py
+++ b/tel2puml/otel_to_puml.py
@@ -67,7 +67,10 @@ def otel_to_puml(
                     Any,
                     None,
                 ],
-            ] = otel_to_pv(**otel_to_pv_options)
+            ] = otel_to_pv(
+                **otel_to_pv_options,
+                output_file_directory=output_file_directory,
+            )
             if components == "otel2pv":
                 return
         case "pv2puml":

--- a/tel2puml/otel_to_pv/otel_to_pv.py
+++ b/tel2puml/otel_to_pv/otel_to_pv.py
@@ -44,7 +44,6 @@ def otel_to_pv(
     :type output_file_directory: `str`
     :rtype: `Generator`[`tuple`[`str`, `Generator`[`Generator`[:class:
     `PVEvent`, `Any`, `None`], `Any`, `None`]], `Any`, `None`]
-
     """
     if ingest_data:
         data_holder = ingest_data_into_dataholder(config)

--- a/tel2puml/tel2puml_types.py
+++ b/tel2puml/tel2puml_types.py
@@ -135,6 +135,7 @@ class OtelPVOptions(TypedDict):
     config: IngestDataConfig
     ingest_data: bool
     save_events: bool
+    find_unique_graphs: bool
 
 
 class PVPumlOptions(TypedDict):

--- a/tel2puml/tel2puml_types.py
+++ b/tel2puml/tel2puml_types.py
@@ -134,6 +134,7 @@ class OtelPVOptions(TypedDict):
 
     config: IngestDataConfig
     ingest_data: bool
+    save_events: bool
 
 
 class PVPumlOptions(TypedDict):

--- a/tests/tel2puml/otel_to_puml/test_otel_to_puml.py
+++ b/tests/tel2puml/otel_to_puml/test_otel_to_puml.py
@@ -64,8 +64,7 @@ class TestOtelToPuml:
             otel_to_puml(otel_to_pv_options=None, components="otel2pv")
         assert (
             "'otel2pv' has been selected, 'otel_to_pv_options' is"
-            " required."
-            in str(exc_info.value)
+            " required." in str(exc_info.value)
         )
 
     @staticmethod
@@ -124,6 +123,7 @@ class TestOtelToPuml:
         otel_options: OtelPVOptions = {
             "config": load_config_from_dict(mock_yaml_config_dict),
             "ingest_data": True,
+            "save_events": False,
         }
 
         otel_to_puml(
@@ -178,13 +178,14 @@ class TestOtelToPuml:
         config = load_config_from_dict(mock_yaml_config_dict)
         config["data_sources"]["json"]["dirpath"] = str(input_dir)
         config["data_sources"]["json"]["filepath"] = None
-        config["data_holders"]["sql"]["db_uri"] = (
-            f'sqlite:///{str(tmp_path / "test.db")}'
-        )
+        config["data_holders"]["sql"][
+            "db_uri"
+        ] = f'sqlite:///{str(tmp_path / "test.db")}'
 
         otel_options: OtelPVOptions = {
             "config": load_config_from_dict(mock_yaml_config_dict),
             "ingest_data": True,
+            "save_events": False,
         }
         # Run function
         otel_to_puml(
@@ -266,3 +267,77 @@ class TestOtelToPuml:
             content = content.strip()
             expected_content = expected_content.strip()
             assert content == expected_content
+
+    @staticmethod
+    def test_save_events(
+        tmp_path: Path,
+        mock_yaml_config_dict: dict[str, Any],
+        mock_json_data: dict[str, Any],
+    ) -> None:
+        """Test successful execution when components='otel2puml' and save
+        events is True."""
+
+        output_dir = tmp_path / "json_output"
+        input_dir = tmp_path / "json_input"
+
+        # Create the input directory
+        input_dir.mkdir(parents=True, exist_ok=True)
+
+        # Write mock_json_data to data.json in input_dir
+        data_file = input_dir / "data.json"
+        data_file.write_text(json.dumps(mock_json_data))
+
+        # Configure config
+        config = load_config_from_dict(mock_yaml_config_dict)
+        config["data_sources"]["json"]["dirpath"] = str(input_dir)
+        config["data_sources"]["json"]["filepath"] = None
+
+        otel_options: OtelPVOptions = {
+            "config": load_config_from_dict(mock_yaml_config_dict),
+            "ingest_data": True,
+            "save_events": True,
+        }
+
+        otel_to_puml(
+            otel_to_pv_options=otel_options,
+            components="otel2puml",
+            output_file_directory=str(output_dir),
+        )
+
+        assert os.listdir(output_dir) == ["Frontend_TestJob"]
+
+        job_json_folder_path = output_dir / "Frontend_TestJob"
+        assert sorted(os.listdir(job_json_folder_path)) == [
+            "pv_event_sequence_1.json",
+            "pv_event_sequence_2.json",
+        ]
+        expected_job_json_content = [
+            {
+                "applicationName": "Processor_1.0",
+                "eventId": "span001",
+                "eventType": "com.T2h.366Yx_500",
+                "jobId": "job_A",
+                "jobName": "Frontend_TestJob",
+                "previousEventIds": ["span002"],
+                "timestamp": "2024-08-13T10:15:32.228220Z",
+            },
+            {
+                "applicationName": "Handler_1.0",
+                "eventId": "span002",
+                "eventType": "com.C36.9ETRp_401",
+                "jobId": "job_A",
+                "jobName": "Frontend_TestJob",
+                "previousEventIds": [],
+                "timestamp": "2024-08-13T10:15:32.229039Z",
+            },
+        ]
+        for i, expected_content in enumerate(
+            expected_job_json_content, start=1
+        ):
+            file_path = job_json_folder_path / f"pv_event_sequence_{i}.json"
+
+            assert file_path.exists()
+
+            with file_path.open("r") as f:
+                file_content = json.load(f)
+                assert file_content == expected_content


### PR DESCRIPTION
This PR extends otel_to_puml to use save_events and output_folder_directory that are now used in pv_to_puml.