### PR TITLE
173 dataholder default max and min timestamp wrong way round

### DIFF
--- a/tel2puml/otel_to_pv/data_holders/base.py
+++ b/tel2puml/otel_to_pv/data_holders/base.py
@@ -19,8 +19,33 @@ class DataHolder(ABC):
     def __init__(self) -> None:
         """Constructor method."""
 
-        self.min_timestamp: int = 999999999999999999999999999999999999999
-        self.max_timestamp: int = 0
+        self._min_timestamp: int = 9223372036854775807
+        self._max_timestamp: int = 0
+
+    @property
+    def max_timestamp(self) -> int:
+        """Property to get the max timestamp. If the max timestamp is less than
+        the min timestamp, return the maximum value of an sqlite int
+        (292 years in nanoseconds).
+
+        :return: The max timestamp
+        :rtype: `int`
+        """
+        if self._max_timestamp < self._min_timestamp:
+            return 9223372036854775807
+        return self._max_timestamp
+
+    @property
+    def min_timestamp(self) -> int:
+        """Property to get the min timestamp. If the min timestamp is greater
+        than the max timestamp, return 0.
+
+        :return: The min timestamp
+        :rtype: `int`
+        """
+        if self._min_timestamp > self._max_timestamp:
+            return 0
+        return self._min_timestamp
 
     def save_data(self, otel_event: OTelEvent) -> None:
         """Method to save an OTelEvent, and keep track of the min and max
@@ -29,10 +54,13 @@ class DataHolder(ABC):
         :param otel_event: An OTelEvent object
         :type otel_event: :class: `OTelEvent`
         """
-        self.min_timestamp = min(
-            self.min_timestamp, otel_event.start_timestamp
+        self._min_timestamp = min(
+            self._min_timestamp, otel_event.start_timestamp
         )
-        self.max_timestamp = max(self.max_timestamp, otel_event.end_timestamp)
+        self._max_timestamp = max(
+            self._max_timestamp,
+            otel_event.end_timestamp
+        )
         self._save_data(otel_event)
 
     def __enter__(self) -> Self:

--- a/tests/tel2puml/otel_to_puml/conftest.py
+++ b/tests/tel2puml/otel_to_puml/conftest.py
@@ -363,8 +363,8 @@ def sql_data_holder_with_otel_jobs(
     sql_data_holder = SQLDataHolder(
         config=mock_sql_config,
     )
-    sql_data_holder.min_timestamp = 10**12
-    sql_data_holder.max_timestamp = 2 * 10**12
+    sql_data_holder._min_timestamp = 10**12
+    sql_data_holder._max_timestamp = 2 * 10**12
     with sql_data_holder:
         for otel_events in otel_jobs.values():
             for otel_event in otel_events:

--- a/tests/tel2puml/otel_to_pv/conftest.py
+++ b/tests/tel2puml/otel_to_pv/conftest.py
@@ -1156,8 +1156,8 @@ def sql_data_holder_with_otel_jobs(
     sql_data_holder = SQLDataHolder(
         config=mock_sql_config,
     )
-    sql_data_holder.min_timestamp = 10**12
-    sql_data_holder.max_timestamp = 2 * 10**12
+    sql_data_holder._min_timestamp = 10**12
+    sql_data_holder._max_timestamp = 2 * 10**12
     with sql_data_holder:
         for otel_events in otel_jobs.values():
             for otel_event in otel_events:
@@ -1181,8 +1181,8 @@ def sql_data_holder_with_multiple_otel_job_names(
     sql_data_holder = SQLDataHolder(
         config=mock_sql_config,
     )
-    sql_data_holder.min_timestamp = 10**12
-    sql_data_holder.max_timestamp = 2 * 10**12
+    sql_data_holder._min_timestamp = 10**12
+    sql_data_holder._max_timestamp = 2 * 10**12
     with sql_data_holder:
         for otel_events in otel_jobs_multiple_job_names.values():
             for otel_event in otel_events:
@@ -1204,8 +1204,8 @@ def sql_data_holder_with_shuffled_otel_events(
     sql_data_holder = SQLDataHolder(
         config=mock_sql_config,
     )
-    sql_data_holder.min_timestamp = 10**12
-    sql_data_holder.max_timestamp = 2 * 10**12
+    sql_data_holder._min_timestamp = 10**12
+    sql_data_holder._max_timestamp = 2 * 10**12
     with sql_data_holder:
         shuffled_tuples = [
             ("1", 0),
@@ -1241,8 +1241,8 @@ def sql_data_holder_otel_jobs_with_job_names_on_root(
     sql_data_holder = SQLDataHolder(
         config=mock_sql_config,
     )
-    sql_data_holder.min_timestamp = 10**12
-    sql_data_holder.max_timestamp = 2 * 10**12
+    sql_data_holder._min_timestamp = 10**12
+    sql_data_holder._max_timestamp = 2 * 10**12
     with sql_data_holder:
         for otel_events in otel_jobs_with_job_names_on_root.values():
             for otel_event in otel_events:

--- a/tests/tel2puml/otel_to_pv/data_holders/sql_data_holder/test_sql_dataholder.py
+++ b/tests/tel2puml/otel_to_pv/data_holders/sql_data_holder/test_sql_dataholder.py
@@ -51,9 +51,9 @@ class TestSQLDataHolder:
             holder = SQLDataHolder(mock_sql_config)
             # Test the super().__init__() method
             assert (
-                holder.min_timestamp == 999999999999999999999999999999999999999
+                holder._min_timestamp == 9223372036854775807
             )
-            assert holder.max_timestamp == 0
+            assert holder._max_timestamp == 0
             # Test attributes set correctly
             assert holder.batch_size == 10
             assert holder.node_models_to_save == []
@@ -473,7 +473,7 @@ class TestSQLDataHolder:
         caplog: LogCaptureFixture,
     ) -> None:
         """Test the remove_jobs_outside_of_time_window function."""
-        sql_data_holder_with_otel_jobs.max_timestamp = 10**12 + 60 * 10**10
+        sql_data_holder_with_otel_jobs._max_timestamp = 10**12 + 60 * 10**10
         caplog.clear()
         caplog.set_level(logging.INFO)
         sql_data_holder_with_otel_jobs.remove_jobs_outside_of_time_window()

--- a/tests/tel2puml/otel_to_pv/data_holders/test_base_data_holder.py
+++ b/tests/tel2puml/otel_to_pv/data_holders/test_base_data_holder.py
@@ -8,12 +8,48 @@ from tel2puml.otel_to_pv.data_holders.base import (
 )
 
 
+class TestDataHolder:
+    """Tests for the DataHolder class."""
+    @staticmethod
+    @pytest.fixture(autouse=True)
+    def _remove_abstract_methods(monkeypatch: MonkeyPatch) -> None:
+        """Remove abstract methods from the DataHolder class."""
+        monkeypatch.setattr(DataHolder, "__abstractmethods__", set())
+
+    @staticmethod
+    def test__init__() -> None:
+        """Test the __init__ method."""
+        data_holder = DataHolder()
+        assert data_holder._max_timestamp == 0
+        assert data_holder._min_timestamp == 9223372036854775807
+
+    @staticmethod
+    def test_max_timestamp() -> None:
+        """Test the max_timestamp property."""
+        data_holder = DataHolder()
+        assert data_holder.max_timestamp == 9223372036854775807
+        data_holder._max_timestamp = 10**12
+        assert data_holder.max_timestamp == 9223372036854775807
+        data_holder._min_timestamp = 0
+        assert data_holder.max_timestamp == 10**12
+
+    @staticmethod
+    def test_min_timestamp() -> None:
+        """Test the min_timestamp property."""
+        data_holder = DataHolder()
+        assert data_holder.min_timestamp == 0
+        data_holder._min_timestamp = 10**12
+        assert data_holder.min_timestamp == 0
+        data_holder._max_timestamp = 2 * 10**12
+        assert data_holder.min_timestamp == 10**12
+
+
 def test_get_time_window(monkeypatch: MonkeyPatch) -> None:
     """Test the get_time_window function."""
     monkeypatch.setattr(DataHolder, "__abstractmethods__", set())
     data_holder = DataHolder()  # type: ignore[abstract]
-    data_holder.min_timestamp = 10**12
-    data_holder.max_timestamp = 2 * 10**12
+    data_holder._min_timestamp = 10**12
+    data_holder._max_timestamp = 2 * 10**12
     time_buffer = 1
     expected_result = (1060000000000, 1940000000000)
     assert get_time_window(time_buffer, data_holder) == expected_result

--- a/tests/tel2puml/otel_to_pv/data_holders/test_base_data_holder.py
+++ b/tests/tel2puml/otel_to_pv/data_holders/test_base_data_holder.py
@@ -19,14 +19,14 @@ class TestDataHolder:
     @staticmethod
     def test__init__() -> None:
         """Test the __init__ method."""
-        data_holder = DataHolder()
+        data_holder = DataHolder()  # type: ignore[abstract]
         assert data_holder._max_timestamp == 0
         assert data_holder._min_timestamp == 9223372036854775807
 
     @staticmethod
     def test_max_timestamp() -> None:
         """Test the max_timestamp property."""
-        data_holder = DataHolder()
+        data_holder = DataHolder()  # type: ignore[abstract]
         assert data_holder.max_timestamp == 9223372036854775807
         data_holder._max_timestamp = 10**12
         assert data_holder.max_timestamp == 9223372036854775807
@@ -36,7 +36,7 @@ class TestDataHolder:
     @staticmethod
     def test_min_timestamp() -> None:
         """Test the min_timestamp property."""
-        data_holder = DataHolder()
+        data_holder = DataHolder()  # type: ignore[abstract]
         assert data_holder.min_timestamp == 0
         data_holder._min_timestamp = 10**12
         assert data_holder.min_timestamp == 0

--- a/tests/tel2puml/otel_to_pv/test_ingest_otel_data.py
+++ b/tests/tel2puml/otel_to_pv/test_ingest_otel_data.py
@@ -188,7 +188,7 @@ def test_fetch_data_holder(mock_yaml_config_dict: dict[str, Any]) -> None:
     data_holder = fetch_data_holder(ingest_data_config)
     assert isinstance(data_holder, SQLDataHolder)
     assert data_holder.batch_size == 5
-    assert data_holder.max_timestamp == 0
-    assert data_holder.min_timestamp == 999999999999999999999999999999999999999
+    assert data_holder.min_timestamp == 0
+    assert data_holder.max_timestamp == 9223372036854775807
     assert not data_holder.node_models_to_save
     assert not data_holder.node_relationships_to_save


### PR DESCRIPTION
PR to update how min and max timestamps are used on dataholder i.e. if the dataholder is full but no data was ingested the timestamps would make no sense