### PR TITLE
184 add option to use jq string query instead of field mapping

### DIFF
--- a/docs/user/Config.md
+++ b/docs/user/Config.md
@@ -51,7 +51,7 @@ This section contains the configuration for the data sources. The following opti
     * `dirpath`: The path to the directory containing the JSON files. This is required if `filepath` is not provided.
     * `filepath`: The path to the JSON file. This is required if `dirpath` is not provided.
     * `json_per_line`: A boolean value indicating whether each line in the JSON file is a separate JSON object. The default value is `false`.
-    * `field_mapping`: The field mapping configuration. The details of how this is used can be found in the [JSON Data Converter HOW TO](/docs/user/json_data_converter_HOWTO.md) section. This is required is `jq_query` is not provided and cannot be used in conjunction with `jq_query`.
+    * `field_mapping`: The field mapping configuration. The details of how this is used can be found in the [JSON Data Converter HOW TO](/docs/user/json_data_converter_HOWTO.md) section. This is required if `jq_query` is not provided and cannot be used in conjunction with `jq_query`.
     * `jq_query`: A jq query to use to extract the data from the JSON file. This is required if `field_mapping` is not provided and cannot be used in conjunction with `field_mapping`. The jq query should return objects representing single events ([OTel Event](/docs/user/json_data_converter_HOWTO.md#1-introduction)). JQ usage can be found at https://jqlang.github.io/jq/.
 
 ### `sequencer`

--- a/docs/user/Config.md
+++ b/docs/user/Config.md
@@ -51,7 +51,8 @@ This section contains the configuration for the data sources. The following opti
     * `dirpath`: The path to the directory containing the JSON files. This is required if `filepath` is not provided.
     * `filepath`: The path to the JSON file. This is required if `dirpath` is not provided.
     * `json_per_line`: A boolean value indicating whether each line in the JSON file is a separate JSON object. The default value is `false`.
-    * `field_mapping`: The field mapping configuration. The details of how this is used can be found in the [JSON Data Converter HOW TO](/docs/user/json_data_converter_HOWTO.md) section.
+    * `field_mapping`: The field mapping configuration. The details of how this is used can be found in the [JSON Data Converter HOW TO](/docs/user/json_data_converter_HOWTO.md) section. This is required is `jq_query` is not provided and cannot be used in conjunction with `jq_query`.
+    * `jq_query`: A jq query to use to extract the data from the JSON file. This is required if `field_mapping` is not provided and cannot be used in conjunction with `field_mapping`. The jq query should return objects representing single events ([OTel Event](/docs/user/json_data_converter_HOWTO.md#1-introduction)). JQ usage can be found at https://jqlang.github.io/jq/.
 
 ### `sequencer`
 This option is not required and can be omitted if the sequencer is not being used or synchronous sequencing is being used.

--- a/docs/user/json_data_converter_HOWTO.md
+++ b/docs/user/json_data_converter_HOWTO.md
@@ -58,6 +58,7 @@ data_sources:
     json:
         dirpath: path/to/json/directory
         filepath: path/to/json/file
+        json_per_line: false
         field_mapping:
             job_name:
                 key_paths: []
@@ -72,6 +73,7 @@ data_sources:
             application_name:
             parent_event_id:
             child_event_ids:
+        jq_query: <jq_query>
 ```
 
 ## 3. Understanding Configuration Settings

--- a/tel2puml/__main__.py
+++ b/tel2puml/__main__.py
@@ -30,7 +30,8 @@ from tel2puml.tel2puml_types import (
     OtelPVOptions,
     PVPumlOptions,
 )
-from tel2puml.otel_to_pv.config import load_config_from_dict
+from tel2puml.otel_to_pv.config import IngestDataConfig
+
 
 parser = argparse.ArgumentParser(prog="otel2puml")
 # global arguments
@@ -193,10 +194,11 @@ def generate_component_options(
     otel_pv_options, pv_puml_options = None, None
     if command == "otel2puml" or command == "otel2pv":
         otel_to_pv_obj = OtelToPVArgs(**args_dict)
+        config = IngestDataConfig(
+            **generate_config(str(otel_to_pv_obj.config_file))
+        )
         otel_pv_options = OtelPVOptions(
-            config=load_config_from_dict(
-                generate_config(str(otel_to_pv_obj.config_file))
-            ),
+            config=config,
             ingest_data=otel_to_pv_obj.ingest_data,
             save_events=otel_to_pv_obj.save_events,
             find_unique_graphs=otel_to_pv_obj.find_unique_graphs,

--- a/tel2puml/otel_to_pv/data_holders/sql_data_holder/sql_dataholder.py
+++ b/tel2puml/otel_to_pv/data_holders/sql_data_holder/sql_dataholder.py
@@ -41,9 +41,9 @@ class SQLDataHolder(DataHolder):
         super().__init__()
         self.node_models_to_save: list[NodeModel] = []
         self.node_relationships_to_save: list[dict[str, str]] = []
-        self.batch_size: int = config["batch_size"]
-        self.time_buffer: int = config["time_buffer"]
-        self.engine: Engine = create_engine(config["db_uri"], echo=False)
+        self.batch_size: int = config.batch_size
+        self.time_buffer: int = config.time_buffer
+        self.engine: Engine = create_engine(config.db_uri, echo=False)
         self.base: Base = Base()
         self.session: Session = Session(bind=self.engine)
         self.create_db_tables()

--- a/tel2puml/otel_to_pv/data_sources/data_sources_config.py
+++ b/tel2puml/otel_to_pv/data_sources/data_sources_config.py
@@ -1,5 +1,6 @@
 """Module for DataSources typed dict."""
-from typing import TypedDict, NotRequired
+from typing import NotRequired
+from typing_extensions import TypedDict
 
 from .json_data_source.json_config import JSONDataSourceConfig
 

--- a/tel2puml/otel_to_pv/data_sources/json_data_source/json_config.py
+++ b/tel2puml/otel_to_pv/data_sources/json_data_source/json_config.py
@@ -304,7 +304,7 @@ def field_spec_mapping_to_jq_field_spec_mapping(
 
 
 class OTelFieldMapping(BaseModel):
-    """Typed dict for OTelFieldMapping - the expected mapping of fields in the
+    """BaseModel for OTelFieldMapping - the expected mapping of fields in the
     used for the JSON data source."""
     job_name: FieldSpec
     job_id: FieldSpec
@@ -338,10 +338,9 @@ class OTelFieldMapping(BaseModel):
 
 
 class JSONDataSourceConfig(BaseModel):
-    """Typed dict for JSONDataSourceConfig."""
+    """BaseModel for JSONDataSourceConfig."""
 
     model_config = ConfigDict(
-        description="The model config",
         required=True,
         strict=True,
         extra="forbid",

--- a/tel2puml/otel_to_pv/data_sources/json_data_source/json_config.py
+++ b/tel2puml/otel_to_pv/data_sources/json_data_source/json_config.py
@@ -341,7 +341,6 @@ class JSONDataSourceConfig(BaseModel):
     """BaseModel for JSONDataSourceConfig."""
 
     model_config = ConfigDict(
-        required=True,
         strict=True,
         extra="forbid",
     )

--- a/tel2puml/otel_to_pv/data_sources/json_data_source/json_config.py
+++ b/tel2puml/otel_to_pv/data_sources/json_data_source/json_config.py
@@ -3,18 +3,28 @@
 from typing import Optional, Union, NotRequired, Iterable, Self, Sequence
 from typing_extensions import TypedDict
 
-from pydantic import BaseModel, model_validator, Field
+from pydantic import BaseModel, model_validator, Field, ConfigDict
 
 
 class FieldSpec(TypedDict):
     """Typed dict for FieldSpec."""
 
-    key_paths: Sequence[str | Iterable[str]]
+    key_paths: Union[Sequence[str | Iterable[str]], str]
     key_value: NotRequired[
-        Optional[Sequence[Optional[Union[str, Iterable[str | None]]]]]
+        Optional[
+            Union[
+                Sequence[Optional[Union[str, Iterable[str | None]]]],
+                str
+            ]
+        ]
     ]
     value_paths: NotRequired[
-        Optional[Sequence[Optional[Union[str, Iterable[str | None]]]]]
+        Optional[
+            Union[
+                Sequence[Optional[Union[str, Iterable[str | None]]]],
+                str
+            ]
+        ]
     ]
     value_type: str
 
@@ -145,15 +155,18 @@ class JQFieldSpec:
 
     @staticmethod
     def field_spec_key_paths_to_jq_field_spec_key_paths(
-        key_paths: Sequence[str | Iterable[str]],
+        key_paths: Union[Sequence[str | Iterable[str]], str],
     ) -> list[tuple[str, ...]]:
         """Converts field spec key paths to jq field spec key paths.
 
         :param key_paths: The key paths
-        :type key_paths: :class:`Sequence`[`str` | `Iterable`[`str`]]
+        :type key_paths: `Union`[`Sequence`[`str` | `Iterable`[`str`]],
+        `str`]
         :return: The jq field spec key paths
         :rtype: `list`[`tuple`[`str`, ...]]
         """
+        if isinstance(key_paths, str):
+            key_paths = [key_paths]
         updated_key_paths: list[tuple[str, ...]] = []
         for key_path in key_paths:
             updated_key_paths.append(
@@ -196,22 +209,26 @@ class JQFieldSpec:
     @staticmethod
     def optional_list_to_jq_optional_list(
         optional_list: Optional[
-            Sequence[Optional[Union[str, Iterable[str | None]]]]
+            Union[
+                Sequence[Optional[Union[str, Iterable[str | None]]]],
+                str
+            ]
         ],
         jq_key_paths: Sequence[tuple[str, ...]],
     ) -> list[tuple[str | None, ...]]:
         """Converts optional list to jq optional list.
 
         :param optional_list: The optional list
-        :type optional_list: `Optional`[`Sequence`[`Optional`[
-        `Union`[`str`, `Iterable`[`str` | `None`]]
-        ]]]
+        :type optional_list: `Optional`[`Union`[`Sequence`[`Optional`[`Union`[
+        `str`, `Iterable`[`str` | `None`]]]], `str`]]
         :param jq_key_paths: The jq key paths
         :type jq_key_paths: `Sequence`[`tuple`[`str`, ...]]
         :return: The jq optional list
         :rtype: `list`[`tuple`[`str` | `None`, ...
         ]]
         """
+        if isinstance(optional_list, str):
+            optional_list = [optional_list]
         updated_optional_list: list[tuple[str | None, ...]] = []
         if optional_list is None:
             optional_list = [None] * len(jq_key_paths)
@@ -322,6 +339,13 @@ class OTelFieldMapping(BaseModel):
 
 class JSONDataSourceConfig(BaseModel):
     """Typed dict for JSONDataSourceConfig."""
+
+    model_config = ConfigDict(
+        description="The model config",
+        required=True,
+        strict=True,
+        extra="forbid",
+    )
 
     filepath: Optional[str] = Field(None, description="The file path")
     dirpath: Optional[str] = Field(None, description="The directory path")

--- a/tel2puml/otel_to_pv/data_sources/json_data_source/json_config.py
+++ b/tel2puml/otel_to_pv/data_sources/json_data_source/json_config.py
@@ -286,7 +286,7 @@ def field_spec_mapping_to_jq_field_spec_mapping(
     }
 
 
-class OTelFieldMapping(TypedDict):
+class OTelFieldMapping(BaseModel):
     """Typed dict for OTelFieldMapping - the expected mapping of fields in the
     used for the JSON data source."""
     job_name: FieldSpec
@@ -297,7 +297,27 @@ class OTelFieldMapping(TypedDict):
     end_timestamp: FieldSpec
     application_name: FieldSpec
     parent_event_id: FieldSpec
-    child_event_ids: NotRequired[FieldSpec]
+    child_event_ids: FieldSpec | None = None
+
+    def to_field_mapping(self) -> dict[str, FieldSpec]:
+        """Converts to field mapping.
+
+        :return: The field mapping
+        :rtype: `dict`[`str`, :class:`FieldSpec`]
+        """
+        field_mapping = {
+            "job_name": self.job_name,
+            "job_id": self.job_id,
+            "event_type": self.event_type,
+            "event_id": self.event_id,
+            "start_timestamp": self.start_timestamp,
+            "end_timestamp": self.end_timestamp,
+            "application_name": self.application_name,
+            "parent_event_id": self.parent_event_id,
+        }
+        if self.child_event_ids is not None:
+            field_mapping["child_event_ids"] = self.child_event_ids
+        return field_mapping
 
 
 class JSONDataSourceConfig(BaseModel):

--- a/tel2puml/otel_to_pv/data_sources/json_data_source/json_datasource.py
+++ b/tel2puml/otel_to_pv/data_sources/json_data_source/json_datasource.py
@@ -39,8 +39,9 @@ class JSONDataSource(OTELDataSource):
                 """No directory or files found. Please check yaml config."""
             )
         self.file_list = self.get_file_list()
+        self.jq_query = get_jq_query_from_config(self.config)
         self.compiled_jq = compile_jq_query(
-            get_jq_query_from_config(self.config)
+            self.jq_query
         )
         self.file_pbar = tqdm(
             total=len(self.file_list),

--- a/tel2puml/otel_to_pv/data_sources/json_data_source/json_datasource.py
+++ b/tel2puml/otel_to_pv/data_sources/json_data_source/json_datasource.py
@@ -7,7 +7,7 @@ from logging import getLogger
 
 from tqdm import tqdm
 from pydantic import ValidationError
-import jq
+import jq  # type: ignore[import-not-found]
 
 from tel2puml.otel_to_pv.otel_to_pv_types import OTelEvent
 from ..base import OTELDataSource
@@ -69,7 +69,7 @@ class JSONDataSource(OTELDataSource):
         elif not os.path.isdir(self.config.dirpath):
             raise ValueError(
                 f"{self.config.dirpath} directory does not exist."
-                )
+            )
         return self.config.dirpath
 
     def set_filepath(self) -> str | None:
@@ -95,7 +95,9 @@ class JSONDataSource(OTELDataSource):
         :rtype: `Any`
         """
         if config.field_mapping is not None:
-            return field_mapping_to_compiled_jq(config.field_mapping)
+            return field_mapping_to_compiled_jq(
+                config.field_mapping.to_field_mapping()
+            )
         elif config.jq_query is not None:
             return jq.compile(config.jq_query)
         else:

--- a/tel2puml/otel_to_pv/ingest_otel_data.py
+++ b/tel2puml/otel_to_pv/ingest_otel_data.py
@@ -1,5 +1,6 @@
 """Module to stream OTel data from a data source and store it within a
 data holder."""
+from typing import TypedDict, Type
 from tel2puml.otel_to_pv.data_holders import (
     SQLDataHolder,
     DataHolder,
@@ -9,6 +10,16 @@ from tel2puml.otel_to_pv.data_sources import (
     OTELDataSource,
 )
 from tel2puml.otel_to_pv.config import IngestDataConfig
+
+
+DATASOURCES = TypedDict(
+    "DATASOURCES", {"json": Type[JSONDataSource]}
+)(json=JSONDataSource)
+
+
+DATAHOLDERS = TypedDict(
+    "DATAHOLDERS", {"sql": Type[SQLDataHolder]}
+)(sql=SQLDataHolder)
 
 
 class IngestData:
@@ -44,12 +55,12 @@ def fetch_data_source(config: IngestDataConfig) -> OTELDataSource:
     :return: The subclass of OTelDataSource
     :rtype: :class: `OTelDataSource`
     """
-    data_source_type = config["ingest_data"].data_source
-    if data_source_type not in config["data_sources"]:
+    data_source_type = config.ingest_data.data_source
+    if data_source_type not in config.data_sources:
         raise ValueError(
             f"{data_source_type} is not present in the data source config."
         )
-    return JSONDataSource(config["data_sources"][data_source_type])
+    return DATASOURCES[data_source_type](config.data_sources[data_source_type])
 
 
 def fetch_data_holder(config: IngestDataConfig) -> DataHolder:
@@ -60,12 +71,13 @@ def fetch_data_holder(config: IngestDataConfig) -> DataHolder:
     :return: The subclass of DataHolder
     :rtype: :class: `DataHolder`
     """
-    data_holder_type = config["ingest_data"].data_holder
-    if data_holder_type not in config["data_holders"]:
+    data_holder_type = config.ingest_data.data_holder
+    data_holders = config.data_holders
+    if data_holder_type not in data_holders:
         raise ValueError(
             f"{data_holder_type} is not present in the data holder config."
         )
-    return SQLDataHolder(config["data_holders"][data_holder_type])
+    return DATAHOLDERS[data_holder_type](data_holders[data_holder_type])
 
 
 def ingest_data_into_dataholder(config: IngestDataConfig) -> DataHolder:

--- a/tel2puml/otel_to_pv/ingest_otel_data.py
+++ b/tel2puml/otel_to_pv/ingest_otel_data.py
@@ -12,14 +12,22 @@ from tel2puml.otel_to_pv.data_sources import (
 from tel2puml.otel_to_pv.config import IngestDataConfig
 
 
-DATASOURCES = TypedDict(
-    "DATASOURCES", {"json": Type[JSONDataSource]}
-)(json=JSONDataSource)
+class DataSourcesTypedDict(TypedDict):
+    """Typed dict for DataSources."""
+
+    json: Type[JSONDataSource]
 
 
-DATAHOLDERS = TypedDict(
-    "DATAHOLDERS", {"sql": Type[SQLDataHolder]}
-)(sql=SQLDataHolder)
+class DataHoldersTypedDict(TypedDict):
+    """Typed dict for DataHolders."""
+
+    sql: Type[SQLDataHolder]
+
+
+DATASOURCES = DataSourcesTypedDict(json=JSONDataSource)
+
+
+DATAHOLDERS = DataHoldersTypedDict(sql=SQLDataHolder)
 
 
 class IngestData:

--- a/tel2puml/otel_to_pv/otel_to_pv.py
+++ b/tel2puml/otel_to_pv/otel_to_pv.py
@@ -6,7 +6,7 @@ from typing import Generator, Any
 
 from tqdm import tqdm
 
-from tel2puml.otel_to_pv.config import IngestDataConfig, SequenceModelConfig
+from tel2puml.otel_to_pv.config import IngestDataConfig
 from tel2puml.otel_to_pv.ingest_otel_data import (
     ingest_data_into_dataholder,
     fetch_data_holder,
@@ -69,7 +69,7 @@ def otel_to_pv(
 
     job_name_group_streams = data_holder.stream_data(job_name_to_job_ids_map)
     # get the async event groups from the config
-    sequencer_config = config.get("sequencer", SequenceModelConfig())
+    sequencer_config = config.sequencer
     async_event_groups = sequencer_config.async_event_groups
     event_name_map_information = sequencer_config.event_name_map_information
     pv_event_gen = (

--- a/tests/tel2puml/otel_to_puml/conftest.py
+++ b/tests/tel2puml/otel_to_puml/conftest.py
@@ -358,11 +358,11 @@ def sql_data_holder_with_otel_jobs(
     mock_sql_config: SQLDataHolderConfig,
 ) -> Generator[SQLDataHolder, Any, None]:
     """Creates a SQLDataHolder object with 5 jobs, each with 2 events."""
-    mock_sql_config["time_buffer"] = 1
-    mock_sql_config["batch_size"] = 2
     sql_data_holder = SQLDataHolder(
         config=mock_sql_config,
     )
+    sql_data_holder.time_buffer = 1
+    sql_data_holder.batch_size = 2
     sql_data_holder._min_timestamp = 10**12
     sql_data_holder._max_timestamp = 2 * 10**12
     with sql_data_holder:

--- a/tests/tel2puml/otel_to_puml/test_otel_to_puml.py
+++ b/tests/tel2puml/otel_to_puml/test_otel_to_puml.py
@@ -116,12 +116,14 @@ class TestOtelToPuml:
         data_file.write_text(json.dumps(mock_json_data))
 
         # Configure config
+        mock_yaml_config_dict["data_sources"]["json"]["dirpath"] = str(
+            input_dir
+        )
+        mock_yaml_config_dict["data_sources"]["json"]["filepath"] = None
         config = load_config_from_dict(mock_yaml_config_dict)
-        config["data_sources"]["json"]["dirpath"] = str(input_dir)
-        config["data_sources"]["json"]["filepath"] = None
 
         otel_options: OtelPVOptions = {
-            "config": load_config_from_dict(mock_yaml_config_dict),
+            "config": config,
             "ingest_data": True,
             "save_events": False,
             "find_unique_graphs": False,
@@ -176,15 +178,17 @@ class TestOtelToPuml:
         data_file.write_text(json.dumps(mock_json_data))
 
         # Configure config
-        config = load_config_from_dict(mock_yaml_config_dict)
-        config["data_sources"]["json"]["dirpath"] = str(input_dir)
-        config["data_sources"]["json"]["filepath"] = None
-        config["data_holders"]["sql"][
+        mock_yaml_config_dict["data_sources"]["json"]["dirpath"] = str(
+            input_dir
+        )
+        mock_yaml_config_dict["data_sources"]["json"]["filepath"] = None
+        mock_yaml_config_dict["data_holders"]["sql"][
             "db_uri"
         ] = f'sqlite:///{str(tmp_path / "test.db")}'
+        config = load_config_from_dict(mock_yaml_config_dict)
 
         otel_options: OtelPVOptions = {
-            "config": load_config_from_dict(mock_yaml_config_dict),
+            "config": config,
             "ingest_data": True,
             "save_events": False,
             "find_unique_graphs": False,
@@ -297,12 +301,14 @@ class TestOtelToPuml:
         data_file.write_text(json.dumps(mock_json_data))
 
         # Configure config
+        mock_yaml_config_dict["data_sources"]["json"]["dirpath"] = str(
+            input_dir
+        )
+        mock_yaml_config_dict["data_sources"]["json"]["filepath"] = None
         config = load_config_from_dict(mock_yaml_config_dict)
-        config["data_sources"]["json"]["dirpath"] = str(input_dir)
-        config["data_sources"]["json"]["filepath"] = None
 
         otel_options: OtelPVOptions = {
-            "config": load_config_from_dict(mock_yaml_config_dict),
+            "config": config,
             "ingest_data": True,
             "save_events": True,
             "find_unique_graphs": False,
@@ -370,12 +376,14 @@ class TestOtelToPuml:
         data_file.write_text(json.dumps(mock_json_data))
 
         # Configure config
+        mock_yaml_config_dict["data_sources"]["json"]["dirpath"] = str(
+            input_dir
+        )
+        mock_yaml_config_dict["data_sources"]["json"]["filepath"] = None
         config = load_config_from_dict(mock_yaml_config_dict)
-        config["data_sources"]["json"]["dirpath"] = str(input_dir)
-        config["data_sources"]["json"]["filepath"] = None
 
         otel_options: OtelPVOptions = {
-            "config": load_config_from_dict(mock_yaml_config_dict),
+            "config": config,
             "ingest_data": False,
             "save_events": False,
             "find_unique_graphs": True,

--- a/tests/tel2puml/otel_to_pv/conftest.py
+++ b/tests/tel2puml/otel_to_pv/conftest.py
@@ -19,7 +19,7 @@ from tel2puml.otel_to_pv.data_holders.sql_data_holder.sql_dataholder import (
     SQLDataHolder,
     intialise_temp_table_for_root_nodes,
 )
-from tel2puml.otel_to_pv.config import SQLDataHolderConfig
+from tel2puml.otel_to_pv.config import SQLDataHolderConfig, IngestDataConfig
 
 
 @pytest.fixture
@@ -104,6 +104,14 @@ def mock_yaml_config_dict(mock_yaml_config_string: str) -> dict[str, Any]:
 
 
 @pytest.fixture
+def mock_ingest_config(
+    mock_yaml_config_dict: dict[str, Any]
+) -> IngestDataConfig:
+    """Mocks the ingest config."""
+    return IngestDataConfig(**mock_yaml_config_dict)
+
+
+@pytest.fixture
 def mock_yaml_config_dict_without_list(
     mock_yaml_config_string: str,
 ) -> dict[str, Any]:
@@ -116,6 +124,14 @@ def mock_yaml_config_dict_without_list(
 
 
 @pytest.fixture
+def mock_ingest_config_without_list(
+    mock_yaml_config_dict_without_list: dict[str, Any],
+) -> IngestDataConfig:
+    """Mocks the ingest config without list."""
+    return IngestDataConfig(**mock_yaml_config_dict_without_list)
+
+
+@pytest.fixture
 def mock_yaml_config_dict_json_per_line(
     mock_yaml_config_string: str,
 ) -> dict[str, Any]:
@@ -123,6 +139,14 @@ def mock_yaml_config_dict_json_per_line(
     config_dict: dict[str, Any] = yaml.safe_load(mock_yaml_config_string)
     config_dict["data_sources"]["json"]["json_per_line"] = True
     return config_dict
+
+
+@pytest.fixture
+def mock_ingest_config_json_per_line(
+    mock_yaml_config_dict_json_per_line: dict[str, Any],
+) -> IngestDataConfig:
+    """Mocks the ingest config with json per line."""
+    return IngestDataConfig(**mock_yaml_config_dict_json_per_line)
 
 
 @pytest.fixture
@@ -1151,11 +1175,11 @@ def sql_data_holder_with_otel_jobs(
     mock_sql_config: SQLDataHolderConfig,
 ) -> Generator[SQLDataHolder, Any, None]:
     """Creates a SQLDataHolder object with 5 jobs, each with 2 events."""
-    mock_sql_config["time_buffer"] = 1
-    mock_sql_config["batch_size"] = 2
     sql_data_holder = SQLDataHolder(
         config=mock_sql_config,
     )
+    sql_data_holder.time_buffer = 1
+    sql_data_holder.batch_size = 2
     sql_data_holder._min_timestamp = 10**12
     sql_data_holder._max_timestamp = 2 * 10**12
     with sql_data_holder:
@@ -1176,11 +1200,11 @@ def sql_data_holder_with_multiple_otel_job_names(
 ) -> Generator[SQLDataHolder, Any, None]:
     """Creates a SQLDataHolder object with 10 jobs consisting of 2 job names,
     each with 2 events."""
-    mock_sql_config["time_buffer"] = 1
-    mock_sql_config["batch_size"] = 2
     sql_data_holder = SQLDataHolder(
         config=mock_sql_config,
     )
+    sql_data_holder.time_buffer = 1
+    sql_data_holder.batch_size = 2
     sql_data_holder._min_timestamp = 10**12
     sql_data_holder._max_timestamp = 2 * 10**12
     with sql_data_holder:
@@ -1200,10 +1224,10 @@ def sql_data_holder_with_shuffled_otel_events(
     mock_sql_config: SQLDataHolderConfig,
 ) -> Generator[SQLDataHolder, Any, None]:
     """Creates a SQLDataHolder object with 5 jobs, each with 2 events."""
-    mock_sql_config["time_buffer"] = 1
     sql_data_holder = SQLDataHolder(
         config=mock_sql_config,
     )
+    sql_data_holder.time_buffer = 1
     sql_data_holder._min_timestamp = 10**12
     sql_data_holder._max_timestamp = 2 * 10**12
     with sql_data_holder:
@@ -1236,11 +1260,11 @@ def sql_data_holder_otel_jobs_with_job_names_on_root(
     mock_sql_config: SQLDataHolderConfig,
 ) -> Generator[SQLDataHolder, Any, None]:
     """Creates a SQLDataHolder object with 5 jobs, each with 2 events."""
-    mock_sql_config["time_buffer"] = 1
-    mock_sql_config["batch_size"] = 2
     sql_data_holder = SQLDataHolder(
         config=mock_sql_config,
     )
+    sql_data_holder.time_buffer = 1
+    sql_data_holder.batch_size = 2
     sql_data_holder._min_timestamp = 10**12
     sql_data_holder._max_timestamp = 2 * 10**12
     with sql_data_holder:

--- a/tests/tel2puml/otel_to_pv/conftest.py
+++ b/tests/tel2puml/otel_to_pv/conftest.py
@@ -39,6 +39,7 @@ def mock_yaml_config_string() -> str:
                     dirpath: /path/to/json/directory
                     filepath: /path/to/json/file.json
                     json_per_line: false
+                    jq_query: null
                     field_mapping:
                         job_name:
                             key_paths: [

--- a/tests/tel2puml/otel_to_pv/data_sources/json_data_source/conftest.py
+++ b/tests/tel2puml/otel_to_pv/data_sources/json_data_source/conftest.py
@@ -77,6 +77,22 @@ def field_mapping(
 
 
 @pytest.fixture
+def field_spec_field_mapping(
+    field_mapping: dict[str, JQFieldSpec]
+) -> dict[str, FieldSpec]:
+    """Fixture for field mapping using previous field specs"""
+    return {
+        k: FieldSpec(
+            key_paths=v.key_paths,
+            key_value=v.key_values,
+            value_paths=v.value_paths,
+            value_type=v.value_type,
+        )
+        for k, v in field_mapping.items()
+    }
+
+
+@pytest.fixture
 def field_spec_with_variables_1() -> JQFieldSpec:
     """Fixture for 1st JQFieldSpec object with variables added"""
     return JQFieldSpec(

--- a/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_datasource.py
+++ b/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_datasource.py
@@ -15,6 +15,9 @@ from unittest.mock import mock_open, patch
 from tel2puml.otel_to_pv.data_sources.json_data_source.json_datasource import (
     JSONDataSource,
 )
+from tel2puml.otel_to_pv.data_sources.json_data_source.json_config import (
+    JSONDataSourceConfig,
+)
 from tel2puml.otel_to_pv.otel_to_pv_types import OTelEvent
 from tel2puml.otel_to_pv.config import IngestDataConfig
 
@@ -25,30 +28,21 @@ class TestJSONDataSource:
     @staticmethod
     @pytest.mark.usefixtures("mock_path_exists")
     def test_get_yaml_config(
-        mock_yaml_config_dict: IngestDataConfig,
+        mock_ingest_config: IngestDataConfig,
     ) -> None:
         """Tests parsing yaml config file and setting config attribute."""
         json_data_source = JSONDataSource(
-            mock_yaml_config_dict["data_sources"]["json"]
+            mock_ingest_config.data_sources["json"]
         )
         config = json_data_source.config
 
         # Check if config is a dictionary
-        assert isinstance(config, dict)
-
-        # Check main config keys
-        expected_keys = {
-            "dirpath",
-            "filepath",
-            "json_per_line",
-            "field_mapping",
-        }
-        assert set(config.keys()) == expected_keys
+        assert isinstance(config, JSONDataSourceConfig)
 
         # Check string values
-        assert config["dirpath"] == "/path/to/json/directory"
-        assert config["filepath"] == "/path/to/json/file.json"
-        assert not config["json_per_line"]
+        assert config.dirpath == "/path/to/json/directory"
+        assert config.filepath == "/path/to/json/file.json"
+        assert not config.json_per_line
 
         # Check expected field mapping keys
         expected_field_mapping_keys = {
@@ -63,62 +57,62 @@ class TestJSONDataSource:
             "child_event_ids",
         }
         assert (
-            set(config["field_mapping"].keys()) == expected_field_mapping_keys
+            set(config.field_mapping.keys()) == expected_field_mapping_keys
         )
 
     @staticmethod
     @pytest.mark.usefixtures("mock_path_exists")
     def test_set_dirpath_valid(
-        mock_yaml_config_dict: IngestDataConfig,
+        mock_ingest_config: IngestDataConfig,
     ) -> None:
         """Tests set_dirpath method."""
         json_data_source = JSONDataSource(
-            mock_yaml_config_dict["data_sources"]["json"]
+            mock_ingest_config.data_sources["json"]
         )
         assert json_data_source.dirpath == "/path/to/json/directory"
 
     @staticmethod
     def test_set_dirpath_invalid(
-        mock_yaml_config_dict: IngestDataConfig,
+        mock_ingest_config: IngestDataConfig,
     ) -> None:
         """Tests the set_dirpath method with a non-existant directory."""
         with patch("os.path.isdir", return_value=False), patch(
             "os.path.isfile", return_value=True
         ):
             with pytest.raises(ValueError, match="directory does not exist"):
-                JSONDataSource(mock_yaml_config_dict["data_sources"]["json"])
+                JSONDataSource(mock_ingest_config.data_sources["json"])
 
     @staticmethod
     @pytest.mark.usefixtures("mock_path_exists")
     def test_set_filepath_valid(
-        mock_yaml_config_dict: IngestDataConfig,
+        mock_ingest_config: IngestDataConfig,
     ) -> None:
         """Tests the set_filepath method."""
         json_data_source = JSONDataSource(
-            mock_yaml_config_dict["data_sources"]["json"]
+            mock_ingest_config.data_sources["json"]
         )
         assert json_data_source.filepath == "/path/to/json/file.json"
 
     @staticmethod
     def test_set_filepath_invalid(
-        mock_yaml_config_dict: IngestDataConfig,
+        mock_ingest_config: IngestDataConfig,
     ) -> None:
         """Tests the set_filepath method with an non-existant file."""
         with patch("os.path.isdir", return_value=True), patch(
             "os.path.isfile", return_value=False
         ):
             with pytest.raises(ValueError, match="does not exist"):
-                JSONDataSource(mock_yaml_config_dict["data_sources"]["json"])
+                JSONDataSource(mock_ingest_config.data_sources["json"])
 
     @staticmethod
     @pytest.mark.usefixtures("mock_path_exists")
     def test_get_file_list(
-        mock_yaml_config_dict: IngestDataConfig, tmp_path: Path
+        mock_ingest_config: IngestDataConfig, tmp_path: Path
     ) -> None:
         """Tests the get_file_list method."""
 
         json_data_source = JSONDataSource(
-            mock_yaml_config_dict["data_sources"]["json"]
+            mock_ingest_config.data_sources["json"]
         )
         # Create temp directory
         temp_dir = tmp_path / "temp_dir"
@@ -186,16 +180,17 @@ class TestJSONDataSource:
         ).replace("filepath: /path/to/json/file.json", 'filepath: ""')
 
         config = yaml.safe_load(invalid_yaml)["data_sources"]["json"]
+        json_data_source_config = JSONDataSourceConfig(**config)
 
         with pytest.raises(
             FileNotFoundError, match="No directory or files found"
         ):
-            JSONDataSource(config)
+            JSONDataSource(json_data_source_config)
 
     @staticmethod
     @pytest.mark.usefixtures("mock_path_exists", "mock_filepath_in_dir")
     def test_parse_json_stream(
-        mock_yaml_config_dict: IngestDataConfig,
+        mock_ingest_config: IngestDataConfig,
         mock_json_data: dict[str, Any],
         caplog: LogCaptureFixture,
     ) -> None:
@@ -203,7 +198,7 @@ class TestJSONDataSource:
         mock_file_content = json.dumps(mock_json_data).encode("utf-8")
         with patch("builtins.open", mock_open(read_data=mock_file_content)):
             json_data_source = JSONDataSource(
-                mock_yaml_config_dict["data_sources"]["json"]
+                mock_ingest_config.data_sources["json"]
             )
             otel_events = json_data_source.parse_json_stream(
                 "/mock/dir/file1.json"
@@ -225,7 +220,7 @@ class TestJSONDataSource:
         mock_file_content = json.dumps(json_data).encode("utf-8")
         with patch("builtins.open", mock_open(read_data=mock_file_content)):
             json_data_source = JSONDataSource(
-                mock_yaml_config_dict["data_sources"]["json"]
+                mock_ingest_config.data_sources["json"]
             )
             caplog.clear()
             caplog.set_level(WARNING)
@@ -284,12 +279,12 @@ class TestJSONDataSource:
     @pytest.mark.parametrize(
         "mock_data, mock_yaml_config",
         [
-            ("mock_json_data", "mock_yaml_config_dict"),
+            ("mock_json_data", "mock_ingest_config"),
             (
                 "mock_json_data_without_list",
-                "mock_yaml_config_dict_without_list",
+                "mock_ingest_config_without_list",
             ),
-            ("mock_json_data", "mock_yaml_config_dict_json_per_line"),
+            ("mock_json_data", "mock_ingest_config_json_per_line"),
         ],
     )
     def test_end_to_end_json_parsing(
@@ -308,8 +303,10 @@ class TestJSONDataSource:
             + b'"injected_error": "\x1b", '
             + mock_file_content[1:]
         )
-        mock_yaml_config_dict = request.getfixturevalue(mock_yaml_config)
-        if mock_yaml_config_dict["data_sources"]["json"]["json_per_line"]:
+        mock_ingest_config: IngestDataConfig = request.getfixturevalue(
+            mock_yaml_config
+        )
+        if mock_ingest_config.data_sources["json"].json_per_line:
             mock_file_content = mock_file_content + b"\n" + mock_file_content
 
         with patch(
@@ -320,9 +317,9 @@ class TestJSONDataSource:
             return_value=["/mock/dir/file1.json"],
         ):
             json_data_source = JSONDataSource(
-                mock_yaml_config_dict["data_sources"]["json"]
+                mock_ingest_config.data_sources["json"]
             )
-            json_data_source.config["dirpath"] = ""
+            json_data_source.config.dirpath = ""
 
             otel_events: list[OTelEvent] = []
             for data in json_data_source:
@@ -379,11 +376,11 @@ class TestJSONDataSource:
             assert otel_event4.child_event_ids is None
 
         # without list
-        if mock_yaml_config == "mock_yaml_config_dict_without_list":
+        if mock_yaml_config == "mock_ingest_config_without_list":
             assert len(otel_events) == 2
             check_otel_events(otel_events, 2)
         # json on each line of file
-        elif mock_yaml_config == "mock_yaml_config_dict_json_per_line":
+        elif mock_yaml_config == "mock_ingest_config_json_per_line":
             assert len(otel_events) == 8
             check_otel_events(otel_events[:4], 4)
             check_otel_events(otel_events[4:], 4)

--- a/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_datasource.py
+++ b/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_datasource.py
@@ -16,7 +16,7 @@ from tel2puml.otel_to_pv.data_sources.json_data_source.json_datasource import (
     JSONDataSource,
 )
 from tel2puml.otel_to_pv.data_sources.json_data_source.json_config import (
-    JSONDataSourceConfig,
+    JSONDataSourceConfig
 )
 from tel2puml.otel_to_pv.otel_to_pv_types import OTelEvent
 from tel2puml.otel_to_pv.config import IngestDataConfig
@@ -43,22 +43,7 @@ class TestJSONDataSource:
         assert config.dirpath == "/path/to/json/directory"
         assert config.filepath == "/path/to/json/file.json"
         assert not config.json_per_line
-
-        # Check expected field mapping keys
-        expected_field_mapping_keys = {
-            "job_name",
-            "job_id",
-            "event_type",
-            "event_id",
-            "start_timestamp",
-            "end_timestamp",
-            "application_name",
-            "parent_event_id",
-            "child_event_ids",
-        }
-        assert (
-            set(config.field_mapping.keys()) == expected_field_mapping_keys
-        )
+        assert config.field_mapping is not None
 
     @staticmethod
     @pytest.mark.usefixtures("mock_path_exists")

--- a/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_datasource.py
+++ b/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_datasource.py
@@ -378,7 +378,7 @@ class TestJSONDataSource:
     @pytest.mark.usefixtures("mock_path_exists", "mock_filepath_in_dir")
     def test_iter_with_input_jq_query() -> None:
         """Tests parsing a json file with a jq query."""
-        config_dict = {
+        config_dict: dict[str, Any] = {
             "filepath": "/path/to/json/file.json",
             "json_per_line": False,
             "field_mapping": None,

--- a/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_jq_converter.py
+++ b/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_jq_converter.py
@@ -587,7 +587,7 @@ class TestFieldMappingToCompiledJQ:
             list(generate_records_from_compiled_jq(data, compiled_jq))
 
     @staticmethod
-    def test_compile_jq_query():
+    def test_compile_jq_query() -> None:
         """Test the compile_jq_query function."""
         jq_query = compile_jq_query(".records[]")
         assert isinstance(jq_query, jq._Program)
@@ -602,6 +602,7 @@ class TestFieldMappingToCompiledJQ:
 
 
 def test_get_jq_query_from_config(monkeypatch: MonkeyPatch) -> None:
+    """Test the get_jq_query_from_config function."""
     # test case where jq query is provided
     config = JSONDataSourceConfig(
         field_mapping=None,
@@ -612,21 +613,27 @@ def test_get_jq_query_from_config(monkeypatch: MonkeyPatch) -> None:
     )
     assert get_jq_query_from_config(config) == "jq_query"
     # test case with field mapping
+    config_dict: dict[str, Any] = {
+        "field_mapping": {
+            field: {"key_paths": "key_path", "value_type": "value_type"}
+            for field in [
+                "job_name",
+                "job_id",
+                "event_type",
+                "event_id",
+                "start_timestamp",
+                "end_timestamp",
+                "application_name",
+                "parent_event_id",
+            ]
+        },
+        "filepath": "filepath",
+        "dirpath": "dirpath",
+        "json_per_line": False,
+        "jq_query": None,
+    }
     config = JSONDataSourceConfig(
-        **dict(
-            field_mapping={
-                field: {"key_paths": "key_path", "value_type": "value_type"}
-                for field in [
-                    "job_name", "job_id", "event_type", "event_id",
-                    "start_timestamp", "end_timestamp", "application_name",
-                    "parent_event_id"
-                ]
-            },
-            filepath="filepath",
-            dirpath="dirpath",
-            json_per_line=False,
-            jq_query=None,
-        )
+        **config_dict
     )
     import tel2puml.otel_to_pv.data_sources.json_data_source.json_jq_converter
     monkeypatch.setattr(

--- a/tests/tel2puml/otel_to_pv/test_config.py
+++ b/tests/tel2puml/otel_to_pv/test_config.py
@@ -17,7 +17,7 @@ def test_load_config_from_dict(mock_yaml_config_dict: dict[str, Any]) -> None:
     """Test load_config_from_yaml_string."""
     otel_to_pv_config = load_config_from_dict(mock_yaml_config_dict)
     # check sequencer default is set
-    assert otel_to_pv_config["sequencer"] == SequenceModelConfig()
+    assert otel_to_pv_config.sequencer == SequenceModelConfig()
     # check case where sequencer is provided
     temp_config = deepcopy(mock_yaml_config_dict)
     temp_config["sequencer"] = {
@@ -30,7 +30,7 @@ def test_load_config_from_dict(mock_yaml_config_dict: dict[str, Any]) -> None:
         "async_flag": True
     }
     otel_to_pv_config = load_config_from_dict(temp_config)
-    assert otel_to_pv_config["sequencer"] == SequenceModelConfig(
+    assert otel_to_pv_config.sequencer == SequenceModelConfig(
         async_event_groups={
             "job_1": {
                 "event_1": {},
@@ -43,7 +43,7 @@ def test_load_config_from_dict(mock_yaml_config_dict: dict[str, Any]) -> None:
     for field in ["data_sources", "data_holders", "ingest_data"]:
         temp_config = deepcopy(mock_yaml_config_dict)
         temp_config.pop(field)
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValidationError):
             load_config_from_dict(temp_config)
     # test case where an fields are not present for ingest_data
     for field in ["data_source", "data_holder"]:

--- a/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
+++ b/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
@@ -236,7 +236,7 @@ class TestOtelToPV:
 
         # Test 7: Remove disconnected spans
         def mock_fetch_data_holder_disconnected_spans(
-            *_
+            *_: Any
         ) -> SQLDataHolder:
             """Remove root span to create disconnected data within NodeModel
             table"""

--- a/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
+++ b/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
@@ -67,9 +67,7 @@ class TestOtelToPV:
             return sql_data_holder
 
         ingest_data_config = IngestDataConfig(
-            data_sources=mock_yaml_config_dict["data_sources"],
-            data_holders=mock_yaml_config_dict["data_holders"],
-            ingest_data=IngestTypes(**mock_yaml_config_dict["ingest_data"]),
+            **mock_yaml_config_dict,
         )
         monkeypatch.setattr(
             "tel2puml.otel_to_pv.otel_to_pv.fetch_data_holder",
@@ -155,7 +153,7 @@ class TestOtelToPV:
         # Test 4: async_flag = True
         # time_buffer = 0
         ingest_config_copy = ingest_data_config.copy()
-        ingest_config_copy["sequencer"] = SequenceModelConfig(async_flag=True)
+        ingest_config_copy.sequencer = SequenceModelConfig(async_flag=True)
         result = otel_to_pv(ingest_config_copy)
         events = []
         valid_event_ids = [f"{i}_{j}" for i in range(5) for j in range(2)]
@@ -177,7 +175,7 @@ class TestOtelToPV:
         assert len(valid_event_ids) == 0
 
         # Test 5: event_to_async_group_map provided in config
-        ingest_data_config["sequencer"] = SequenceModelConfig(
+        ingest_data_config.sequencer = SequenceModelConfig(
             async_event_groups={
                 "test_name": event_to_async_group_map,
             }
@@ -204,7 +202,7 @@ class TestOtelToPV:
         assert all(job_id_count[job_id] == 2 for job_id in valid_job_ids)
         assert len(valid_event_ids) == 0
         # Test 6: event_name_map_information provided in config
-        ingest_data_config["sequencer"] = SequenceModelConfig(
+        ingest_data_config.sequencer = SequenceModelConfig(
             event_name_map_information={
                 "test_name": {
                     "event_type_0": OTelEventTypeMap(
@@ -238,7 +236,7 @@ class TestOtelToPV:
 
         # Test 7: Remove disconnected spans
         def mock_fetch_data_holder_disconnected_spans(
-            config: IngestDataConfig,
+            *_
         ) -> SQLDataHolder:
             """Remove root span to create disconnected data within NodeModel
             table"""
@@ -251,9 +249,7 @@ class TestOtelToPV:
             return sql_data_holder
 
         ingest_data_config = IngestDataConfig(
-            data_sources=mock_yaml_config_dict["data_sources"],
-            data_holders=mock_yaml_config_dict["data_holders"],
-            ingest_data=IngestTypes(**mock_yaml_config_dict["ingest_data"]),
+            **mock_yaml_config_dict,
         )
         monkeypatch.setattr(
             "tel2puml.otel_to_pv.otel_to_pv.fetch_data_holder",
@@ -321,9 +317,7 @@ class TestOtelToPV:
 
         output_dir = tmp_path / "json_output"
         ingest_data_config = IngestDataConfig(
-            data_sources=mock_yaml_config_dict["data_sources"],
-            data_holders=mock_yaml_config_dict["data_holders"],
-            ingest_data=IngestTypes(**mock_yaml_config_dict["ingest_data"]),
+            **mock_yaml_config_dict,
         )
         monkeypatch.setattr(
             "tel2puml.otel_to_pv.otel_to_pv.fetch_data_holder",


### PR DESCRIPTION
PR to update JSON config to be able to use input jq query string. 

Also updates the following:

- For strictness of config use almost everything now uses PyDantic BaseModel to ensure correct usage of config fields for user
- Ensures a user can provide just a single string to `key_paths` in a FieldSpec for the most basic of cases