### PR TITLE
195-pv-conversion-using-schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ python -m tel2puml otel2pv -c CONFIG_FILE [options]
 - `-ni`, `--no-ingest`: Do not load data into the data holder.
 - `-ug`, `--unique-graphs`: Find unique graphs within the data holder.
 - `-se`, `--save-events`: Save PVEvents in intermediate format.
+- `-mc`, `--mapping-config`: Path to the mapping configuration file. [Usage](docs/user/mapping_config.md)
 
 **Example:**
 
@@ -336,6 +337,7 @@ python -m tel2puml pv2puml [options] [FILE_PATHS...]
 - `FILE_PATHS`: One or more files containing job data. Cannot be used with `-fp`.
 - `-jn`, `--job-name`: Name for the PlantUML sequence diagram and output file prefix (default is `"default_name"`).
 - `-group-by-job`: Group events by job ID.
+- `-mc`, `--mapping-config`: Path to the mapping configuration file. [Usage](docs/user/mapping_config.md)
 
 **Notes:**
 

--- a/docs/user/mapping_config.md
+++ b/docs/user/mapping_config.md
@@ -1,0 +1,58 @@
+# OTel to PUML Mapping Config file
+# ========================
+
+The `tel2puml` tool allows a custom mapping configuration file to be specified using the `--mapping-config` or `-mc` flag. This mapping configuration file maps application-specific data fields to the corresponding fields in the `PVEvent` object, ensuring that the conversion process correctly translates the data.
+
+## Example Mapping Configuration (`mapping_config.yaml`)
+
+A typical `mapping_config.yaml` file would look like this:
+
+```yaml
+# Configuration file for mapping application data to user data for PVEvent objects.
+jobId: jobIdNew
+eventId: eventIdNew
+timestamp: timestampNew
+previousEventIds: previousEventIdsNew
+applicationName: applicationNameNew
+jobName: jobNameNew
+eventType: eventTypeNew
+```
+
+Each key in the configuration file represents a field in the PVEvent object, and its value represents the corresponding key in the application data.
+
+## When to Use a Custom Mapping Configuration
+
+A custom `mapping_config.yaml` file is used when the structure of the data does not match the default `PVEvent` schema. Defining a custom mapping ensures that data fields are correctly translated into the required format for generating PlantUML diagrams or PV formats.
+
+## Default Behaviour Without a Mapping Configuration
+
+If no mapping configuration file is provided, `tel2puml` uses its default internal mappings for the `PVEvent` object. A custom mapping configuration is only necessary when the data structure deviates from the default schema.
+
+## Example of Custom Mapping Configuration
+
+In cases where application data fields do not match the default field names used in `PVEvent`, a custom mapping configuration can be defined. For instance, consider the following data structure for an event:
+
+```json
+{
+    "job_identifier": "1234",
+    "event_identifier": "abcd-efgh",
+    "time_of_event": "2023-10-15T12:34:56Z",
+    "previous_event_ids": ["prev-123"],
+    "app_name": "my_application",
+    "job_name": "test_job",
+    "type_of_event": "A"
+}
+```
+
+In this example, the default `PVEvent` field names such as `jobId`, `eventId`, and `timestamp` do not align with the application data field names. To handle this, a custom mapping_config.yaml file can be created to map the application fields to the corresponding `PVEvent` fields:
+
+```yaml
+# Custom mapping_config.yaml
+jobId: job_identifier
+eventId: event_identifier
+timestamp: time_of_event
+previousEventIds: previous_event_ids
+applicationName: app_name
+jobName: job_name
+eventType: type_of_event
+```

--- a/docs/user/mapping_config.md
+++ b/docs/user/mapping_config.md
@@ -26,7 +26,7 @@ A custom `mapping_config.yaml` file is used when the structure of the data does 
 
 ## Default Behaviour Without a Mapping Configuration
 
-If no mapping configuration file is provided, `tel2puml` uses its default internal mappings for the `PVEvent` object. A custom mapping configuration is only necessary when the data structure deviates from the default schema.
+If no mapping configuration file is provided, `tel2puml` uses its default [internal mappings](/tel2puml/mapping_config.yaml) for the `PVEvent` object. A custom mapping configuration is only necessary when the data structure deviates from the default schema.
 
 ## Example of Custom Mapping Configuration
 

--- a/tel2puml/__main__.py
+++ b/tel2puml/__main__.py
@@ -205,23 +205,22 @@ def generate_component_options(
     """
 
     otel_pv_options, pv_puml_options = None, None
-    mapping_config = PVEventMappingConfig()
     if command == "otel2puml" or command == "otel2pv":
         otel_to_pv_obj = OtelToPVArgs(**args_dict)
         config = IngestDataConfig(
             **generate_config(str(otel_to_pv_obj.config_file))
         )
-        if otel_to_pv_obj.mapping_config_file:
-            mapping_config = PVEventMappingConfig(
-                **generate_config(str(otel_to_pv_obj.mapping_config_file))
-            )
         otel_pv_options = OtelPVOptions(
             config=config,
             ingest_data=otel_to_pv_obj.ingest_data,
             save_events=otel_to_pv_obj.save_events,
             find_unique_graphs=otel_to_pv_obj.find_unique_graphs,
-            mapping_config=mapping_config,
         )
+        if otel_to_pv_obj.mapping_config_file:
+            mapping_config = PVEventMappingConfig(
+                **generate_config(str(otel_to_pv_obj.mapping_config_file))
+            )
+            otel_pv_options.mapping_config = mapping_config
     elif command == "pv2puml":
         pv_to_puml_obj = PvToPumlArgs(**args_dict)
         if pv_to_puml_obj.file_paths:
@@ -230,16 +229,16 @@ def generate_component_options(
             ]
         elif pv_to_puml_obj.folder_path:
             file_list = find_files(str(pv_to_puml_obj.folder_path))
-        if pv_to_puml_obj.mapping_config_file:
-            mapping_config = PVEventMappingConfig(
-                **generate_config(str(pv_to_puml_obj.mapping_config_file))
-            )
         pv_puml_options = PVPumlOptions(
             file_list=file_list,
             job_name=pv_to_puml_obj.job_name,
             group_by_job_id=pv_to_puml_obj.group_by_job,
-            mapping_config=mapping_config,
         )
+        if pv_to_puml_obj.mapping_config_file:
+            mapping_config = PVEventMappingConfig(
+                **generate_config(str(pv_to_puml_obj.mapping_config_file))
+            )
+            pv_puml_options.mapping_config = mapping_config
 
     return otel_pv_options, pv_puml_options
 

--- a/tel2puml/__main__.py
+++ b/tel2puml/__main__.py
@@ -253,11 +253,9 @@ if __name__ == "__main__":
     otel_pv_options, pv_puml_options = generate_component_options(
         args.command, args_dict
     )
-    import pprint
-    pprint.pp(otel_pv_options)
-    # otel_to_puml(
-    #     otel_pv_options,
-    #     pv_puml_options,
-    #     args_dict["output_file_directory"],
-    #     args.command,
-    # )
+    otel_to_puml(
+        otel_pv_options,
+        pv_puml_options,
+        args_dict["output_file_directory"],
+        args.command,
+    )

--- a/tel2puml/__main__.py
+++ b/tel2puml/__main__.py
@@ -220,7 +220,7 @@ def generate_component_options(
             mapping_config = PVEventMappingConfig(
                 **generate_config(str(otel_to_pv_obj.mapping_config_file))
             )
-            otel_pv_options.mapping_config = mapping_config
+            otel_pv_options["mapping_config"] = mapping_config
     elif command == "pv2puml":
         pv_to_puml_obj = PvToPumlArgs(**args_dict)
         if pv_to_puml_obj.file_paths:
@@ -238,7 +238,7 @@ def generate_component_options(
             mapping_config = PVEventMappingConfig(
                 **generate_config(str(pv_to_puml_obj.mapping_config_file))
             )
-            pv_puml_options.mapping_config = mapping_config
+            pv_puml_options["mapping_config"] = mapping_config
 
     return otel_pv_options, pv_puml_options
 

--- a/tel2puml/__main__.py
+++ b/tel2puml/__main__.py
@@ -30,7 +30,7 @@ from tel2puml.tel2puml_types import (
     PvToPumlArgs,
     OtelPVOptions,
     PVPumlOptions,
-    MappingConfig
+    PVEventMappingConfig
 )
 from tel2puml.otel_to_pv.config import IngestDataConfig
 
@@ -212,7 +212,7 @@ def generate_component_options(
         )
         mapping_config = None
         if otel_to_pv_obj.mapping_config_file:
-            mapping_config = MappingConfig(
+            mapping_config = PVEventMappingConfig(
                 **generate_config(str(otel_to_pv_obj.mapping_config_file))
             )
         otel_pv_options = OtelPVOptions(
@@ -232,7 +232,7 @@ def generate_component_options(
             file_list = find_files(str(pv_to_puml_obj.folder_path))
         mapping_config = None
         if pv_to_puml_obj.mapping_config_file:
-            mapping_config = MappingConfig(
+            mapping_config = PVEventMappingConfig(
                 **generate_config(str(pv_to_puml_obj.mapping_config_file))
             )
         pv_puml_options = PVPumlOptions(

--- a/tel2puml/__main__.py
+++ b/tel2puml/__main__.py
@@ -205,12 +205,12 @@ def generate_component_options(
     """
 
     otel_pv_options, pv_puml_options = None, None
+    mapping_config = PVEventMappingConfig()
     if command == "otel2puml" or command == "otel2pv":
         otel_to_pv_obj = OtelToPVArgs(**args_dict)
         config = IngestDataConfig(
             **generate_config(str(otel_to_pv_obj.config_file))
         )
-        mapping_config = None
         if otel_to_pv_obj.mapping_config_file:
             mapping_config = PVEventMappingConfig(
                 **generate_config(str(otel_to_pv_obj.mapping_config_file))
@@ -230,7 +230,6 @@ def generate_component_options(
             ]
         elif pv_to_puml_obj.folder_path:
             file_list = find_files(str(pv_to_puml_obj.folder_path))
-        mapping_config = None
         if pv_to_puml_obj.mapping_config_file:
             mapping_config = PVEventMappingConfig(
                 **generate_config(str(pv_to_puml_obj.mapping_config_file))

--- a/tel2puml/mapping_config.yaml
+++ b/tel2puml/mapping_config.yaml
@@ -1,0 +1,8 @@
+# Configuration file for mapping application data to user data for PVEvent objects.
+jobId: jobId
+eventId: eventId
+timestamp: timestamp
+previousEventIds: previousEventIds
+applicationName: applicationName
+jobName: jobName
+eventType: eventType

--- a/tel2puml/otel_to_pv/otel_to_pv.py
+++ b/tel2puml/otel_to_pv/otel_to_pv.py
@@ -21,7 +21,7 @@ def otel_to_pv(
     find_unique_graphs: bool = False,
     save_events: bool = False,
     output_file_directory: str = ".",
-    mapping_config: PVEventMappingConfig = PVEventMappingConfig(),
+    mapping_config: PVEventMappingConfig | None = None,
 ) -> Generator[
     tuple[str, Generator[Generator[PVEvent, Any, None], Any, None]], Any, None
 ]:
@@ -46,8 +46,8 @@ def otel_to_pv(
     :param output_file_directory: Output file directory.
     :type output_file_directory: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
-    objects. Defaults to `PVEventMappingConfig`.
-    :type mapping_config: :class: `PVEventMappingConfig`
+    objects. Defaults to `None`.
+    :type mapping_config: :class:`PVEventMappingConfig` | `None`
     :rtype: `Generator`[`tuple`[`str`, `Generator`[`Generator`[:class:
     `PVEvent`, `Any`, `None`], `Any`, `None`]], `Any`, `None`]
     """
@@ -113,7 +113,7 @@ def handle_save_events(
         None,
     ],
     output_file_directory: str,
-    mapping_config: PVEventMappingConfig = PVEventMappingConfig(),
+    mapping_config: PVEventMappingConfig | None = None,
 ) -> None:
     """Function to handle the save events flag. Saves PVEvents as job json
     files within a job folder within the output file directory.
@@ -126,8 +126,8 @@ def handle_save_events(
     :param output_file_directory: Output file directory
     :type output_file_directory: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
-    objects. Defaults to `PVEventMappingConfig`.
-    :type mapping_config: :class: `PVEventMappingConfig`
+    objects. Defaults to `None`.
+    :type mapping_config: :class:`PVEventMappingConfig` | `None`
     """
     try:
         os.makedirs(f"{output_file_directory}/{job_name}", exist_ok=True)
@@ -156,7 +156,7 @@ def save_pv_event_stream_to_file(
     pv_event_stream: Generator[PVEvent, Any, None],
     output_file_directory: str,
     count: int,
-    mapping_config: PVEventMappingConfig = PVEventMappingConfig(),
+    mapping_config: PVEventMappingConfig | None = None,
 ) -> None:
     """Saves a PVEvent as a json file to a folder within the output directory.
 
@@ -167,8 +167,8 @@ def save_pv_event_stream_to_file(
     :type count: `int`
     :type output_file_directory: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
-    objects. Defaults to `PVEventMappingConfig`.
-    :type mapping_config: :class: `PVEventMappingConfig`
+    objects. Defaults to `None`.
+    :type mapping_config: :class:`PVEventMappingConfig` | `None`
     """
     try:
         if mapping_config is None:

--- a/tel2puml/otel_to_pv/otel_to_pv.py
+++ b/tel2puml/otel_to_pv/otel_to_pv.py
@@ -45,6 +45,9 @@ def otel_to_pv(
     :type save_events: bool
     :param output_file_directory: Output file directory.
     :type output_file_directory: `str`
+    :param mapping_config: Mapping application data to user data for PVEvent
+    objects.
+    :type mapping_config: :class: `MappingConfig`
     :rtype: `Generator`[`tuple`[`str`, `Generator`[`Generator`[:class:
     `PVEvent`, `Any`, `None`], `Any`, `None`]], `Any`, `None`]
     """

--- a/tel2puml/otel_to_pv/otel_to_pv.py
+++ b/tel2puml/otel_to_pv/otel_to_pv.py
@@ -21,7 +21,7 @@ def otel_to_pv(
     find_unique_graphs: bool = False,
     save_events: bool = False,
     output_file_directory: str = ".",
-    mapping_config: PVEventMappingConfig | None = None,
+    mapping_config: PVEventMappingConfig = PVEventMappingConfig(),
 ) -> Generator[
     tuple[str, Generator[Generator[PVEvent, Any, None], Any, None]], Any, None
 ]:
@@ -46,7 +46,7 @@ def otel_to_pv(
     :param output_file_directory: Output file directory.
     :type output_file_directory: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
-    objects. Defaults to `None`.
+    objects. Defaults to `PVEventMappingConfig`.
     :type mapping_config: :class: `PVEventMappingConfig`
     :rtype: `Generator`[`tuple`[`str`, `Generator`[`Generator`[:class:
     `PVEvent`, `Any`, `None`], `Any`, `None`]], `Any`, `None`]
@@ -126,7 +126,7 @@ def handle_save_events(
     :param output_file_directory: Output file directory
     :type output_file_directory: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
-    objects. Defaults to `None`.
+    objects. Defaults to `PVEventMappingConfig`.
     :type mapping_config: :class: `PVEventMappingConfig`
     """
     try:
@@ -167,7 +167,7 @@ def save_pv_event_stream_to_file(
     :type count: `int`
     :type output_file_directory: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
-    objects. Defaults to `None`.
+    objects. Defaults to `PVEventMappingConfig`.
     :type mapping_config: :class: `PVEventMappingConfig`
     """
     try:

--- a/tel2puml/otel_to_pv/otel_to_pv.py
+++ b/tel2puml/otel_to_pv/otel_to_pv.py
@@ -46,7 +46,7 @@ def otel_to_pv(
     :param output_file_directory: Output file directory.
     :type output_file_directory: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
-    objects.
+    objects. Defaults to `None`.
     :type mapping_config: :class: `MappingConfig`
     :rtype: `Generator`[`tuple`[`str`, `Generator`[`Generator`[:class:
     `PVEvent`, `Any`, `None`], `Any`, `None`]], `Any`, `None`]
@@ -125,6 +125,9 @@ def handle_save_events(
     `None`], `Any`, `None`, ]
     :param output_file_directory: Output file directory
     :type output_file_directory: `str`
+    :param mapping_config: Mapping application data to user data for PVEvent
+    objects. Defaults to `None`.
+    :type mapping_config: :class: `MappingConfig`
     """
     try:
         os.makedirs(f"{output_file_directory}/{job_name}", exist_ok=True)
@@ -163,9 +166,12 @@ def save_pv_event_stream_to_file(
     :param count: Current file number
     :type count: `int`
     :type output_file_directory: `str`
+    :param mapping_config: Mapping application data to user data for PVEvent
+    objects. Defaults to `None`.
+    :type mapping_config: :class: `MappingConfig`
     """
     try:
-        if not mapping_config:
+        if mapping_config is None:
             pv_event_list: list[PVEvent] | list[dict[str, Any]] = list(
                 pv_event_stream
             )

--- a/tel2puml/otel_to_pv/otel_to_pv.py
+++ b/tel2puml/otel_to_pv/otel_to_pv.py
@@ -113,7 +113,7 @@ def handle_save_events(
         None,
     ],
     output_file_directory: str,
-    mapping_config: PVEventMappingConfig | None,
+    mapping_config: PVEventMappingConfig = PVEventMappingConfig(),
 ) -> None:
     """Function to handle the save events flag. Saves PVEvents as job json
     files within a job folder within the output file directory.
@@ -156,7 +156,7 @@ def save_pv_event_stream_to_file(
     pv_event_stream: Generator[PVEvent, Any, None],
     output_file_directory: str,
     count: int,
-    mapping_config: PVEventMappingConfig | None,
+    mapping_config: PVEventMappingConfig = PVEventMappingConfig(),
 ) -> None:
     """Saves a PVEvent as a json file to a folder within the output directory.
 

--- a/tel2puml/otel_to_pv/otel_to_pv.py
+++ b/tel2puml/otel_to_pv/otel_to_pv.py
@@ -12,7 +12,7 @@ from tel2puml.otel_to_pv.ingest_otel_data import (
     fetch_data_holder,
 )
 from tel2puml.otel_to_pv.sequence_otel import sequence_otel_job_id_streams
-from tel2puml.tel2puml_types import PVEvent, MappingConfig
+from tel2puml.tel2puml_types import PVEvent, PVEventMappingConfig
 
 
 def otel_to_pv(
@@ -21,7 +21,7 @@ def otel_to_pv(
     find_unique_graphs: bool = False,
     save_events: bool = False,
     output_file_directory: str = ".",
-    mapping_config: MappingConfig | None = None,
+    mapping_config: PVEventMappingConfig | None = None,
 ) -> Generator[
     tuple[str, Generator[Generator[PVEvent, Any, None], Any, None]], Any, None
 ]:
@@ -47,7 +47,7 @@ def otel_to_pv(
     :type output_file_directory: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `None`.
-    :type mapping_config: :class: `MappingConfig`
+    :type mapping_config: :class: `PVEventMappingConfig`
     :rtype: `Generator`[`tuple`[`str`, `Generator`[`Generator`[:class:
     `PVEvent`, `Any`, `None`], `Any`, `None`]], `Any`, `None`]
     """
@@ -113,7 +113,7 @@ def handle_save_events(
         None,
     ],
     output_file_directory: str,
-    mapping_config: MappingConfig | None,
+    mapping_config: PVEventMappingConfig | None,
 ) -> None:
     """Function to handle the save events flag. Saves PVEvents as job json
     files within a job folder within the output file directory.
@@ -127,7 +127,7 @@ def handle_save_events(
     :type output_file_directory: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `None`.
-    :type mapping_config: :class: `MappingConfig`
+    :type mapping_config: :class: `PVEventMappingConfig`
     """
     try:
         os.makedirs(f"{output_file_directory}/{job_name}", exist_ok=True)
@@ -156,7 +156,7 @@ def save_pv_event_stream_to_file(
     pv_event_stream: Generator[PVEvent, Any, None],
     output_file_directory: str,
     count: int,
-    mapping_config: MappingConfig | None,
+    mapping_config: PVEventMappingConfig | None,
 ) -> None:
     """Saves a PVEvent as a json file to a folder within the output directory.
 
@@ -168,7 +168,7 @@ def save_pv_event_stream_to_file(
     :type output_file_directory: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `None`.
-    :type mapping_config: :class: `MappingConfig`
+    :type mapping_config: :class: `PVEventMappingConfig`
     """
     try:
         if mapping_config is None:

--- a/tel2puml/otel_to_pv/otel_to_pv.py
+++ b/tel2puml/otel_to_pv/otel_to_pv.py
@@ -12,7 +12,7 @@ from tel2puml.otel_to_pv.ingest_otel_data import (
     fetch_data_holder,
 )
 from tel2puml.otel_to_pv.sequence_otel import sequence_otel_job_id_streams
-from tel2puml.tel2puml_types import PVEvent
+from tel2puml.tel2puml_types import PVEvent, MappingConfig
 
 
 def otel_to_pv(
@@ -21,6 +21,7 @@ def otel_to_pv(
     find_unique_graphs: bool = False,
     save_events: bool = False,
     output_file_directory: str = ".",
+    mapping_config: MappingConfig | None = None
 ) -> Generator[
     tuple[str, Generator[Generator[PVEvent, Any, None], Any, None]], Any, None
 ]:

--- a/tel2puml/pv_event_simulator.py
+++ b/tel2puml/pv_event_simulator.py
@@ -9,7 +9,7 @@ from tel2puml.tel2puml_types import (
     DUMMY_START_EVENT,
     PVEvent,
     DUMMY_EVENT,
-    MappingConfig,
+    PVEventMappingConfig,
 )
 
 
@@ -257,7 +257,7 @@ def remove_dummy_start_event_from_event_sequence(
 
 
 def transform_dict_into_pv_event(
-    pv_dict: dict[str, Any], mapping_config: MappingConfig | None = None
+    pv_dict: dict[str, Any], mapping_config: PVEventMappingConfig | None = None
 ) -> PVEvent:
     """This function transforms a dictionary into a pv event.
 
@@ -265,7 +265,7 @@ def transform_dict_into_pv_event(
     :type pv_dict: `dict`[`str`, `Any`]
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `None`
-    :type mapping_config: :class: `MappingConfig`
+    :type mapping_config: :class: `PVEventMappingConfig`
     :return: The pv event.
     :rtype: :class:`PVEvent`
     """

--- a/tel2puml/pv_event_simulator.py
+++ b/tel2puml/pv_event_simulator.py
@@ -280,11 +280,13 @@ def transform_dict_into_pv_event(
         }
     else:
         mandatory_fields = {
-            field for field in mapping_config.model_dump().values()
+            field
+            for key, field in mapping_config.model_dump().items()
+            if key != "previousEventIds"
         }
     if not mandatory_fields.issubset(pv_dict.keys()):
         raise ValueError(
-            "The dictionary does not contain all the mandatory " "fields."
+            "The dictionary does not contain all the mandatory fields."
         )
     pv_event = PVEvent(
         eventId=(
@@ -318,11 +320,17 @@ def transform_dict_into_pv_event(
             else pv_dict[mapping_config.jobName]
         ),
     )
-    if "previousEventIds" in pv_dict:
-        if isinstance(pv_dict["previousEventIds"], str):
-            pv_event["previousEventIds"] = [pv_dict["previousEventIds"]]
-        elif isinstance(pv_dict["previousEventIds"], list):
-            pv_event["previousEventIds"] = pv_dict["previousEventIds"]
+    previous_event_ids_key = (
+        "previousEventIds"
+        if not mapping_config
+        else mapping_config.previousEventIds
+    )
+
+    if previous_event_ids_key in pv_dict:
+        if isinstance(pv_dict[previous_event_ids_key], str):
+            pv_event["previousEventIds"] = [pv_dict[previous_event_ids_key]]
+        elif isinstance(pv_dict[previous_event_ids_key], list):
+            pv_event["previousEventIds"] = pv_dict[previous_event_ids_key]
         else:
             raise ValueError(
                 "The previousEventIds field is not a string or a list."

--- a/tel2puml/pv_event_simulator.py
+++ b/tel2puml/pv_event_simulator.py
@@ -5,7 +5,7 @@ import random
 from uuid import uuid4
 
 from test_event_generator.io.run import puml_file_to_test_events  # type: ignore[import-untyped]  # noqa: E501
-from tel2puml.tel2puml_types import DUMMY_START_EVENT, PVEvent, DUMMY_EVENT
+from tel2puml.tel2puml_types import DUMMY_START_EVENT, PVEvent, DUMMY_EVENT, MappingConfig
 
 
 class Job:
@@ -252,11 +252,15 @@ def remove_dummy_start_event_from_event_sequence(
 
 def transform_dict_into_pv_event(
     pv_dict: dict[str, Any],
+    mapping_config: MappingConfig | None = None
 ) -> PVEvent:
     """This function transforms a dictionary into a pv event.
 
     :param pv_dict: The dictionary to transform.
     :type pv_dict: `dict`[`str`, `Any`]
+    :param mapping_config: Mapping application data to user data for PVEvent
+    objects. Defaults to `None`
+    :type mapping_config: :class: `MappingConfig`
     :return: The pv event.
     :rtype: :class:`PVEvent`
     """

--- a/tel2puml/pv_event_simulator.py
+++ b/tel2puml/pv_event_simulator.py
@@ -264,7 +264,7 @@ def transform_dict_into_pv_event(
     :param pv_dict: The dictionary to transform.
     :type pv_dict: `dict`[`str`, `Any`]
     :param mapping_config: Mapping application data to user data for PVEvent
-    objects. Defaults to `None`
+    objects. Defaults to `PVEventMappingConfig`
     :type mapping_config: :class: `PVEventMappingConfig`
     :return: The pv event.
     :rtype: :class:`PVEvent`

--- a/tel2puml/pv_event_simulator.py
+++ b/tel2puml/pv_event_simulator.py
@@ -5,7 +5,12 @@ import random
 from uuid import uuid4
 
 from test_event_generator.io.run import puml_file_to_test_events  # type: ignore[import-untyped]  # noqa: E501
-from tel2puml.tel2puml_types import DUMMY_START_EVENT, PVEvent, DUMMY_EVENT, MappingConfig
+from tel2puml.tel2puml_types import (
+    DUMMY_START_EVENT,
+    PVEvent,
+    DUMMY_EVENT,
+    MappingConfig,
+)
 
 
 class Job:
@@ -54,9 +59,7 @@ class Job:
         if not set([*previous_events, event["eventId"]]).issubset(
             event_id_map.keys()
         ):
-            raise ValueError(
-                "The some event ids are not in the event id map."
-            )
+            raise ValueError("The some event ids are not in the event id map.")
         sim_event = event.copy()
         sim_event["eventId"] = event_id_map[event["eventId"]]
         sim_event["jobId"] = job_id
@@ -83,9 +86,7 @@ class Job:
         event_id_map: dict[str, str] = self.create_new_event_id_map()
         job_id = str(uuid4())
         for event in self.events:
-            yield self.sim_event(
-                event, job_id, event_id_map
-            )
+            yield self.sim_event(event, job_id, event_id_map)
 
 
 def generate_test_data(
@@ -114,8 +115,10 @@ def generate_test_data(
     :rtype: `Generator[PVEvent, Any, None]`
     """
     for event_sequence in generate_test_data_event_sequences_from_puml(
-        input_puml_file, template_all_paths, num_paths_to_template,
-        is_branch_puml
+        input_puml_file,
+        template_all_paths,
+        num_paths_to_template,
+        is_branch_puml,
     ):
         yield from event_sequence
 
@@ -151,16 +154,19 @@ def generate_test_data_event_sequences_from_puml(
     `Any`, `None`]
     """
     test_job_templates = [
-        job for job in generate_valid_jobs_from_puml_file(
+        job
+        for job in generate_valid_jobs_from_puml_file(
             input_puml_file,
         )
     ]
     if is_branch_puml:
         test_job_templates.extend(
-            [job for job in generate_valid_jobs_from_puml_file(
-                input_puml_file,
-                num_branches=3
-            )]
+            [
+                job
+                for job in generate_valid_jobs_from_puml_file(
+                    input_puml_file, num_branches=3
+                )
+            ]
         )
     counter = 0
     if template_all_paths:
@@ -184,7 +190,7 @@ def generate_test_data_event_sequences_from_puml(
 
 
 def remove_dummy_start_event_from_event_sequence(
-    event_sequence: Generator[PVEvent, Any, None]
+    event_sequence: Generator[PVEvent, Any, None],
 ) -> Generator[PVEvent, Any, None]:
     """This function removes the dummy start event from an event sequence that
     is given the appropriate event type.
@@ -251,8 +257,7 @@ def remove_dummy_start_event_from_event_sequence(
 
 
 def transform_dict_into_pv_event(
-    pv_dict: dict[str, Any],
-    mapping_config: MappingConfig | None = None
+    pv_dict: dict[str, Any], mapping_config: MappingConfig | None = None
 ) -> PVEvent:
     """This function transforms a dictionary into a pv event.
 
@@ -264,22 +269,54 @@ def transform_dict_into_pv_event(
     :return: The pv event.
     :rtype: :class:`PVEvent`
     """
-    mandatory_fields = {
-        "eventId", "eventType", "jobId", "timestamp", "applicationName",
-        "jobName"
-    }
+    if not mapping_config:
+        mandatory_fields = {
+            "eventId",
+            "eventType",
+            "jobId",
+            "timestamp",
+            "applicationName",
+            "jobName",
+        }
+    else:
+        mandatory_fields = {
+            field for field in mapping_config.model_dump().values()
+        }
     if not mandatory_fields.issubset(pv_dict.keys()):
         raise ValueError(
-            "The dictionary does not contain all the mandatory "
-            "fields."
+            "The dictionary does not contain all the mandatory " "fields."
         )
     pv_event = PVEvent(
-        eventId=pv_dict["eventId"],
-        eventType=pv_dict["eventType"],
-        jobId=pv_dict["jobId"],
-        timestamp=pv_dict["timestamp"],
-        applicationName=pv_dict["applicationName"],
-        jobName=pv_dict["jobName"],
+        eventId=(
+            pv_dict["eventId"]
+            if not mapping_config
+            else pv_dict[mapping_config.eventId]
+        ),
+        eventType=(
+            pv_dict["eventType"]
+            if not mapping_config
+            else pv_dict[mapping_config.eventType]
+        ),
+        jobId=(
+            pv_dict["jobId"]
+            if not mapping_config
+            else pv_dict[mapping_config.jobId]
+        ),
+        timestamp=(
+            pv_dict["timestamp"]
+            if not mapping_config
+            else pv_dict[mapping_config.timestamp]
+        ),
+        applicationName=(
+            pv_dict["applicationName"]
+            if not mapping_config
+            else pv_dict[mapping_config.applicationName]
+        ),
+        jobName=(
+            pv_dict["jobName"]
+            if not mapping_config
+            else pv_dict[mapping_config.jobName]
+        ),
     )
     if "previousEventIds" in pv_dict:
         if isinstance(pv_dict["previousEventIds"], str):

--- a/tel2puml/pv_event_simulator.py
+++ b/tel2puml/pv_event_simulator.py
@@ -269,7 +269,7 @@ def transform_dict_into_pv_event(
     :return: The pv event.
     :rtype: :class:`PVEvent`
     """
-    if not mapping_config:
+    if mapping_config is None:
         mandatory_fields = {
             "eventId",
             "eventType",
@@ -291,38 +291,38 @@ def transform_dict_into_pv_event(
     pv_event = PVEvent(
         eventId=(
             pv_dict["eventId"]
-            if not mapping_config
+            if mapping_config is None
             else pv_dict[mapping_config.eventId]
         ),
         eventType=(
             pv_dict["eventType"]
-            if not mapping_config
+            if mapping_config is None
             else pv_dict[mapping_config.eventType]
         ),
         jobId=(
             pv_dict["jobId"]
-            if not mapping_config
+            if mapping_config is None
             else pv_dict[mapping_config.jobId]
         ),
         timestamp=(
             pv_dict["timestamp"]
-            if not mapping_config
+            if mapping_config is None
             else pv_dict[mapping_config.timestamp]
         ),
         applicationName=(
             pv_dict["applicationName"]
-            if not mapping_config
+            if mapping_config is None
             else pv_dict[mapping_config.applicationName]
         ),
         jobName=(
             pv_dict["jobName"]
-            if not mapping_config
+            if mapping_config is None
             else pv_dict[mapping_config.jobName]
         ),
     )
     previous_event_ids_key = (
         "previousEventIds"
-        if not mapping_config
+        if mapping_config is None
         else mapping_config.previousEventIds
     )
 

--- a/tel2puml/pv_event_simulator.py
+++ b/tel2puml/pv_event_simulator.py
@@ -257,7 +257,8 @@ def remove_dummy_start_event_from_event_sequence(
 
 
 def transform_dict_into_pv_event(
-    pv_dict: dict[str, Any], mapping_config: PVEventMappingConfig | None = None
+    pv_dict: dict[str, Any],
+    mapping_config: PVEventMappingConfig = PVEventMappingConfig(),
 ) -> PVEvent:
     """This function transforms a dictionary into a pv event.
 
@@ -269,68 +270,32 @@ def transform_dict_into_pv_event(
     :return: The pv event.
     :rtype: :class:`PVEvent`
     """
-    if mapping_config is None:
-        mandatory_fields = {
-            "eventId",
-            "eventType",
-            "jobId",
-            "timestamp",
-            "applicationName",
-            "jobName",
-        }
-    else:
-        mandatory_fields = {
-            field
-            for key, field in mapping_config.model_dump().items()
-            if key != "previousEventIds"
-        }
+    mandatory_fields = {
+        field
+        for key, field in mapping_config.model_dump().items()
+        if key != "previousEventIds"
+    }
     if not mandatory_fields.issubset(pv_dict.keys()):
         raise ValueError(
             "The dictionary does not contain all the mandatory fields."
         )
     pv_event = PVEvent(
-        eventId=(
-            pv_dict["eventId"]
-            if mapping_config is None
-            else pv_dict[mapping_config.eventId]
-        ),
-        eventType=(
-            pv_dict["eventType"]
-            if mapping_config is None
-            else pv_dict[mapping_config.eventType]
-        ),
-        jobId=(
-            pv_dict["jobId"]
-            if mapping_config is None
-            else pv_dict[mapping_config.jobId]
-        ),
-        timestamp=(
-            pv_dict["timestamp"]
-            if mapping_config is None
-            else pv_dict[mapping_config.timestamp]
-        ),
-        applicationName=(
-            pv_dict["applicationName"]
-            if mapping_config is None
-            else pv_dict[mapping_config.applicationName]
-        ),
-        jobName=(
-            pv_dict["jobName"]
-            if mapping_config is None
-            else pv_dict[mapping_config.jobName]
-        ),
-    )
-    previous_event_ids_key = (
-        "previousEventIds"
-        if mapping_config is None
-        else mapping_config.previousEventIds
+        eventId=(pv_dict[mapping_config.eventId]),
+        eventType=(pv_dict[mapping_config.eventType]),
+        jobId=(pv_dict[mapping_config.jobId]),
+        timestamp=(pv_dict[mapping_config.timestamp]),
+        applicationName=(pv_dict[mapping_config.applicationName]),
+        jobName=(pv_dict[mapping_config.jobName]),
     )
 
-    if previous_event_ids_key in pv_dict:
-        if isinstance(pv_dict[previous_event_ids_key], str):
-            pv_event["previousEventIds"] = [pv_dict[previous_event_ids_key]]
-        elif isinstance(pv_dict[previous_event_ids_key], list):
-            pv_event["previousEventIds"] = pv_dict[previous_event_ids_key]
+    if mapping_config.previousEventIds in pv_dict:
+        prev_event_id: str | list[str] = pv_dict[
+            mapping_config.previousEventIds
+        ]
+        if isinstance(prev_event_id, str):
+            pv_event["previousEventIds"] = [prev_event_id]
+        elif isinstance(prev_event_id, list):
+            pv_event["previousEventIds"] = prev_event_id
         else:
             raise ValueError(
                 "The previousEventIds field is not a string or a list."

--- a/tel2puml/pv_event_simulator.py
+++ b/tel2puml/pv_event_simulator.py
@@ -266,7 +266,7 @@ def transform_dict_into_pv_event(
     :type pv_dict: `dict`[`str`, `Any`]
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `PVEventMappingConfig`
-    :type mapping_config: :class: `PVEventMappingConfig`
+    :type mapping_config: :class:`PVEventMappingConfig`
     :return: The pv event.
     :rtype: :class:`PVEvent`
     """

--- a/tel2puml/pv_to_puml/pv_to_puml.py
+++ b/tel2puml/pv_to_puml/pv_to_puml.py
@@ -22,9 +22,9 @@ from tel2puml.pv_to_puml.walk_puml_graph.node_update import (
     update_nested_node_graph_with_break_points,
 )
 from tel2puml.loop_detection.detect_loops import detect_loops
-from tel2puml.pv_to_puml.walk_puml_graph.create_node_graph_from_event_graph import (
-    create_node_graph_from_event_graph,
-)
+from tel2puml.pv_to_puml.walk_puml_graph. \
+    create_node_graph_from_event_graph \
+    import create_node_graph_from_event_graph
 from tel2puml.pv_to_puml.walk_puml_graph.find_and_add_loop_kill_paths import (
     find_and_add_loop_kill_paths_to_nested_graphs,
 )

--- a/tel2puml/pv_to_puml/pv_to_puml.py
+++ b/tel2puml/pv_to_puml/pv_to_puml.py
@@ -120,11 +120,15 @@ def pv_event_file_to_event(
 
 def pv_job_file_to_event_sequence(
     file_path: str,
+    mapping_config: MappingConfig | None = None
 ) -> list[PVEvent]:
     """Reads a PV job json array file and returns the event sequence
 
     :param file_path: The path to the PV job json file
     :type file_path: `str`
+    :param mapping_config: Mapping application data to user data for PVEvent
+    objects. Defaults to `None`
+    :type mapping_config: :class: `MappingConfig`
     :return: The event sequence
     :rtype: `list`[:class:`PVEvent`]
     """
@@ -136,7 +140,7 @@ def pv_job_file_to_event_sequence(
     for event in data:
         if not isinstance(event, dict):
             raise ValueError("The file does not contain a list of events")
-        out_data.append(transform_dict_into_pv_event(event))
+        out_data.append(transform_dict_into_pv_event(event, mapping_config))
     return out_data
 
 
@@ -160,17 +164,21 @@ def pv_events_from_files_to_event_stream(
 
 def pv_job_files_to_event_sequence_streams(
     file_paths: list[str],
+    mapping_config: MappingConfig | None = None
 ) -> Generator[list[PVEvent], Any, None]:
     """Reads a list of PV job json array files and yields the event sequences
     when iterated over
 
     :param file_paths: The paths to the PV job json files
     :type file_paths: `list`[`str`]
+    :param mapping_config: Mapping application data to user data for PVEvent
+    objects. Defaults to `None`
+    :type mapping_config: :class: `MappingConfig`
     :return: A generator of event sequences
     :rtype: `Generator`[`list`[:class:`PVEvent`], Any, None]
     """
     for file_path in file_paths:
-        yield pv_job_file_to_event_sequence(file_path)
+        yield pv_job_file_to_event_sequence(file_path, mapping_config)
 
 
 def pv_jobs_from_folder_to_event_sequence_streams(
@@ -303,5 +311,7 @@ def pv_files_to_pv_streams(
             file_list, mapping_config
         )
     else:
-        pv_stream_sequence = pv_job_files_to_event_sequence_streams(file_list)
+        pv_stream_sequence = pv_job_files_to_event_sequence_streams(
+            file_list, mapping_config
+        )
     yield (job_name, pv_stream_sequence)

--- a/tel2puml/pv_to_puml/pv_to_puml.py
+++ b/tel2puml/pv_to_puml/pv_to_puml.py
@@ -22,10 +22,9 @@ from tel2puml.pv_to_puml.walk_puml_graph.node_update import (
     update_nested_node_graph_with_break_points,
 )
 from tel2puml.loop_detection.detect_loops import detect_loops
-from tel2puml.pv_to_puml.walk_puml_graph.\
-    create_node_graph_from_event_graph import (
-    create_node_graph_from_event_graph,
-)
+from tel2puml.pv_to_puml.walk_puml_graph \
+    .create_node_graph_from_event_graph \
+    import create_node_graph_from_event_graph
 from tel2puml.pv_to_puml.walk_puml_graph.find_and_add_loop_kill_paths import (
     find_and_add_loop_kill_paths_to_nested_graphs,
 )

--- a/tel2puml/pv_to_puml/pv_to_puml.py
+++ b/tel2puml/pv_to_puml/pv_to_puml.py
@@ -22,7 +22,8 @@ from tel2puml.pv_to_puml.walk_puml_graph.node_update import (
     update_nested_node_graph_with_break_points,
 )
 from tel2puml.loop_detection.detect_loops import detect_loops
-from tel2puml.pv_to_puml.walk_puml_graph.create_node_graph_from_event_graph import (
+from tel2puml.pv_to_puml.walk_puml_graph.\
+    create_node_graph_from_event_graph import (
     create_node_graph_from_event_graph,
 )
 from tel2puml.pv_to_puml.walk_puml_graph.find_and_add_loop_kill_paths import (
@@ -119,8 +120,7 @@ def pv_event_file_to_event(
 
 
 def pv_job_file_to_event_sequence(
-    file_path: str,
-    mapping_config: MappingConfig | None = None
+    file_path: str, mapping_config: MappingConfig | None = None
 ) -> list[PVEvent]:
     """Reads a PV job json array file and returns the event sequence
 
@@ -163,8 +163,7 @@ def pv_events_from_files_to_event_stream(
 
 
 def pv_job_files_to_event_sequence_streams(
-    file_paths: list[str],
-    mapping_config: MappingConfig | None = None
+    file_paths: list[str], mapping_config: MappingConfig | None = None
 ) -> Generator[list[PVEvent], Any, None]:
     """Reads a list of PV job json array files and yields the event sequences
     when iterated over

--- a/tel2puml/pv_to_puml/pv_to_puml.py
+++ b/tel2puml/pv_to_puml/pv_to_puml.py
@@ -8,7 +8,7 @@ import os
 
 from tqdm import tqdm
 
-from tel2puml.tel2puml_types import PVEvent
+from tel2puml.tel2puml_types import PVEvent, MappingConfig
 from tel2puml.pv_to_puml.data_ingestion import (
     cluster_events_by_job_id,
     update_and_create_events_from_clustered_pvevents,
@@ -256,6 +256,7 @@ def pv_files_to_pv_streams(
     file_list: list[str] | None = None,
     job_name: str = "default.puml",
     group_by_job_id: Optional[bool] = False,
+    mapping_config: MappingConfig | None = None
 ) -> Generator[
     tuple[str, Generator[list[PVEvent], Any, None]],
     Any,

--- a/tel2puml/pv_to_puml/pv_to_puml.py
+++ b/tel2puml/pv_to_puml/pv_to_puml.py
@@ -120,7 +120,8 @@ def pv_event_file_to_event(
 
 
 def pv_job_file_to_event_sequence(
-    file_path: str, mapping_config: PVEventMappingConfig = PVEventMappingConfig()
+    file_path: str,
+    mapping_config: PVEventMappingConfig = PVEventMappingConfig(),
 ) -> list[PVEvent]:
     """Reads a PV job json array file and returns the event sequence
 

--- a/tel2puml/pv_to_puml/pv_to_puml.py
+++ b/tel2puml/pv_to_puml/pv_to_puml.py
@@ -108,7 +108,7 @@ def pv_event_file_to_event(
     :type file_path: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `PVEventMappingConfig`
-    :type mapping_config: :class: `PVEventMappingConfig`
+    :type mapping_config: :class:`PVEventMappingConfig`
     :return: The event
     :rtype: :class:`PVEvent`
     """
@@ -129,7 +129,7 @@ def pv_job_file_to_event_sequence(
     :type file_path: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `PVEventMappingConfig`
-    :type mapping_config: :class: `PVEventMappingConfig`
+    :type mapping_config: :class:`PVEventMappingConfig`
     :return: The event sequence
     :rtype: `list`[:class:`PVEvent`]
     """
@@ -156,7 +156,7 @@ def pv_events_from_files_to_event_stream(
     :type file_paths: `list`[`str`]
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `PVEventMappingConfig`
-    :type mapping_config: :class: `PVEventMappingConfig`
+    :type mapping_config: :class:`PVEventMappingConfig`
     :return: A generator of events
     :rtype: `Generator`[:class:`PVEvent`, Any, None]
     """
@@ -175,7 +175,7 @@ def pv_job_files_to_event_sequence_streams(
     :type file_paths: `list`[`str`]
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `PVEventMappingConfig`
-    :type mapping_config: :class: `PVEventMappingConfig`
+    :type mapping_config: :class:`PVEventMappingConfig`
     :return: A generator of event sequences
     :rtype: `Generator`[`list`[:class:`PVEvent`], Any, None]
     """
@@ -234,7 +234,7 @@ def pv_event_files_to_job_id_streams(
     :type file_list: `Optional`[`list`[`str`]]
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `PVEventMappingConfig`
-    :type mapping_config: :class: `PVEventMappingConfig`
+    :type mapping_config: :class:`PVEventMappingConfig`
     :return: A generator that yields lists of PVEvents grouped by job_id.
     :rtype: `Generator`[`list`[:class:`PVEvent`], `Any`, `None`]
     """
@@ -302,7 +302,7 @@ def pv_files_to_pv_streams(
     and a generator of lists of PVEvents.
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `PVEventMappingConfig`
-    :type mapping_config: :class: `PVEventMappingConfig`
+    :type mapping_config: :class:`PVEventMappingConfig`
     :rtype: `Generator`[`tuple`[`str`,`Generator`[list[PVEvent]], `Any`,
     `None`]],`Any`,`None`]
     """

--- a/tel2puml/pv_to_puml/pv_to_puml.py
+++ b/tel2puml/pv_to_puml/pv_to_puml.py
@@ -22,9 +22,9 @@ from tel2puml.pv_to_puml.walk_puml_graph.node_update import (
     update_nested_node_graph_with_break_points,
 )
 from tel2puml.loop_detection.detect_loops import detect_loops
-from tel2puml.pv_to_puml.walk_puml_graph \
-    .create_node_graph_from_event_graph \
-    import create_node_graph_from_event_graph
+from tel2puml.pv_to_puml.walk_puml_graph.create_node_graph_from_event_graph import (
+    create_node_graph_from_event_graph,
+)
 from tel2puml.pv_to_puml.walk_puml_graph.find_and_add_loop_kill_paths import (
     find_and_add_loop_kill_paths_to_nested_graphs,
 )
@@ -99,7 +99,8 @@ def pv_to_puml_file(
 
 
 def pv_event_file_to_event(
-    file_path: str, mapping_config: PVEventMappingConfig | None = None
+    file_path: str,
+    mapping_config: PVEventMappingConfig = PVEventMappingConfig(),
 ) -> PVEvent:
     """Reads a PV event json file and returns the event
 
@@ -144,7 +145,8 @@ def pv_job_file_to_event_sequence(
 
 
 def pv_events_from_files_to_event_stream(
-    file_paths: list[str], mapping_config: PVEventMappingConfig | None = None
+    file_paths: list[str],
+    mapping_config: PVEventMappingConfig = PVEventMappingConfig(),
 ) -> Generator[PVEvent, Any, None]:
     """Reads a list of PV event json files and yields the events when iterated
     over
@@ -162,7 +164,8 @@ def pv_events_from_files_to_event_stream(
 
 
 def pv_job_files_to_event_sequence_streams(
-    file_paths: list[str], mapping_config: PVEventMappingConfig | None = None
+    file_paths: list[str],
+    mapping_config: PVEventMappingConfig = PVEventMappingConfig(),
 ) -> Generator[list[PVEvent], Any, None]:
     """Reads a list of PV job json array files and yields the event sequences
     when iterated over
@@ -220,7 +223,7 @@ def pv_jobs_from_folder_to_puml_file(
 
 def pv_event_files_to_job_id_streams(
     file_list: list[str] | None = None,
-    mapping_config: PVEventMappingConfig | None = None,
+    mapping_config: PVEventMappingConfig = PVEventMappingConfig(),
 ) -> Generator[list[PVEvent], Any, None]:
     """File list of pv event files into a generator of lists of PV event
     sequences grouped by job_id.
@@ -273,7 +276,7 @@ def pv_files_to_pv_streams(
     file_list: list[str] | None = None,
     job_name: str = "default.puml",
     group_by_job_id: Optional[bool] = False,
-    mapping_config: PVEventMappingConfig | None = None,
+    mapping_config: PVEventMappingConfig = PVEventMappingConfig(),
 ) -> Generator[
     tuple[str, Generator[list[PVEvent], Any, None]],
     Any,

--- a/tel2puml/pv_to_puml/pv_to_puml.py
+++ b/tel2puml/pv_to_puml/pv_to_puml.py
@@ -120,7 +120,7 @@ def pv_event_file_to_event(
 
 
 def pv_job_file_to_event_sequence(
-    file_path: str, mapping_config: PVEventMappingConfig | None = None
+    file_path: str, mapping_config: PVEventMappingConfig = PVEventMappingConfig()
 ) -> list[PVEvent]:
     """Reads a PV job json array file and returns the event sequence
 

--- a/tel2puml/pv_to_puml/pv_to_puml.py
+++ b/tel2puml/pv_to_puml/pv_to_puml.py
@@ -107,7 +107,7 @@ def pv_event_file_to_event(
     :param file_path: The path to the PV event json file
     :type file_path: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
-    objects. Defaults to `None`
+    objects. Defaults to `PVEventMappingConfig`
     :type mapping_config: :class: `PVEventMappingConfig`
     :return: The event
     :rtype: :class:`PVEvent`
@@ -127,7 +127,7 @@ def pv_job_file_to_event_sequence(
     :param file_path: The path to the PV job json file
     :type file_path: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
-    objects. Defaults to `None`
+    objects. Defaults to `PVEventMappingConfig`
     :type mapping_config: :class: `PVEventMappingConfig`
     :return: The event sequence
     :rtype: `list`[:class:`PVEvent`]
@@ -154,7 +154,7 @@ def pv_events_from_files_to_event_stream(
     :param file_paths: The paths to the PV event json files
     :type file_paths: `list`[`str`]
     :param mapping_config: Mapping application data to user data for PVEvent
-    objects. Defaults to `None`
+    objects. Defaults to `PVEventMappingConfig`
     :type mapping_config: :class: `PVEventMappingConfig`
     :return: A generator of events
     :rtype: `Generator`[:class:`PVEvent`, Any, None]
@@ -173,7 +173,7 @@ def pv_job_files_to_event_sequence_streams(
     :param file_paths: The paths to the PV job json files
     :type file_paths: `list`[`str`]
     :param mapping_config: Mapping application data to user data for PVEvent
-    objects. Defaults to `None`
+    objects. Defaults to `PVEventMappingConfig`
     :type mapping_config: :class: `PVEventMappingConfig`
     :return: A generator of event sequences
     :rtype: `Generator`[`list`[:class:`PVEvent`], Any, None]
@@ -232,7 +232,7 @@ def pv_event_files_to_job_id_streams(
     to `None`.
     :type file_list: `Optional`[`list`[`str`]]
     :param mapping_config: Mapping application data to user data for PVEvent
-    objects. Defaults to `None`
+    objects. Defaults to `PVEventMappingConfig`
     :type mapping_config: :class: `PVEventMappingConfig`
     :return: A generator that yields lists of PVEvents grouped by job_id.
     :rtype: `Generator`[`list`[:class:`PVEvent`], `Any`, `None`]
@@ -300,7 +300,7 @@ def pv_files_to_pv_streams(
     :return: A generator that yields tuples. Each tuple contains the job name
     and a generator of lists of PVEvents.
     :param mapping_config: Mapping application data to user data for PVEvent
-    objects. Defaults to `None`
+    objects. Defaults to `PVEventMappingConfig`
     :type mapping_config: :class: `PVEventMappingConfig`
     :rtype: `Generator`[`tuple`[`str`,`Generator`[list[PVEvent]], `Any`,
     `None`]],`Any`,`None`]

--- a/tel2puml/pv_to_puml/pv_to_puml.py
+++ b/tel2puml/pv_to_puml/pv_to_puml.py
@@ -8,7 +8,7 @@ import os
 
 from tqdm import tqdm
 
-from tel2puml.tel2puml_types import PVEvent, MappingConfig
+from tel2puml.tel2puml_types import PVEvent, PVEventMappingConfig
 from tel2puml.pv_to_puml.data_ingestion import (
     cluster_events_by_job_id,
     update_and_create_events_from_clustered_pvevents,
@@ -99,7 +99,7 @@ def pv_to_puml_file(
 
 
 def pv_event_file_to_event(
-    file_path: str, mapping_config: MappingConfig | None = None
+    file_path: str, mapping_config: PVEventMappingConfig | None = None
 ) -> PVEvent:
     """Reads a PV event json file and returns the event
 
@@ -107,7 +107,7 @@ def pv_event_file_to_event(
     :type file_path: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `None`
-    :type mapping_config: :class: `MappingConfig`
+    :type mapping_config: :class: `PVEventMappingConfig`
     :return: The event
     :rtype: :class:`PVEvent`
     """
@@ -119,7 +119,7 @@ def pv_event_file_to_event(
 
 
 def pv_job_file_to_event_sequence(
-    file_path: str, mapping_config: MappingConfig | None = None
+    file_path: str, mapping_config: PVEventMappingConfig | None = None
 ) -> list[PVEvent]:
     """Reads a PV job json array file and returns the event sequence
 
@@ -127,7 +127,7 @@ def pv_job_file_to_event_sequence(
     :type file_path: `str`
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `None`
-    :type mapping_config: :class: `MappingConfig`
+    :type mapping_config: :class: `PVEventMappingConfig`
     :return: The event sequence
     :rtype: `list`[:class:`PVEvent`]
     """
@@ -144,7 +144,7 @@ def pv_job_file_to_event_sequence(
 
 
 def pv_events_from_files_to_event_stream(
-    file_paths: list[str], mapping_config: MappingConfig | None = None
+    file_paths: list[str], mapping_config: PVEventMappingConfig | None = None
 ) -> Generator[PVEvent, Any, None]:
     """Reads a list of PV event json files and yields the events when iterated
     over
@@ -153,7 +153,7 @@ def pv_events_from_files_to_event_stream(
     :type file_paths: `list`[`str`]
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `None`
-    :type mapping_config: :class: `MappingConfig`
+    :type mapping_config: :class: `PVEventMappingConfig`
     :return: A generator of events
     :rtype: `Generator`[:class:`PVEvent`, Any, None]
     """
@@ -162,7 +162,7 @@ def pv_events_from_files_to_event_stream(
 
 
 def pv_job_files_to_event_sequence_streams(
-    file_paths: list[str], mapping_config: MappingConfig | None = None
+    file_paths: list[str], mapping_config: PVEventMappingConfig | None = None
 ) -> Generator[list[PVEvent], Any, None]:
     """Reads a list of PV job json array files and yields the event sequences
     when iterated over
@@ -171,7 +171,7 @@ def pv_job_files_to_event_sequence_streams(
     :type file_paths: `list`[`str`]
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `None`
-    :type mapping_config: :class: `MappingConfig`
+    :type mapping_config: :class: `PVEventMappingConfig`
     :return: A generator of event sequences
     :rtype: `Generator`[`list`[:class:`PVEvent`], Any, None]
     """
@@ -220,7 +220,7 @@ def pv_jobs_from_folder_to_puml_file(
 
 def pv_event_files_to_job_id_streams(
     file_list: list[str] | None = None,
-    mapping_config: MappingConfig | None = None,
+    mapping_config: PVEventMappingConfig | None = None,
 ) -> Generator[list[PVEvent], Any, None]:
     """File list of pv event files into a generator of lists of PV event
     sequences grouped by job_id.
@@ -230,7 +230,7 @@ def pv_event_files_to_job_id_streams(
     :type file_list: `Optional`[`list`[`str`]]
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `None`
-    :type mapping_config: :class: `MappingConfig`
+    :type mapping_config: :class: `PVEventMappingConfig`
     :return: A generator that yields lists of PVEvents grouped by job_id.
     :rtype: `Generator`[`list`[:class:`PVEvent`], `Any`, `None`]
     """
@@ -273,7 +273,7 @@ def pv_files_to_pv_streams(
     file_list: list[str] | None = None,
     job_name: str = "default.puml",
     group_by_job_id: Optional[bool] = False,
-    mapping_config: MappingConfig | None = None,
+    mapping_config: PVEventMappingConfig | None = None,
 ) -> Generator[
     tuple[str, Generator[list[PVEvent], Any, None]],
     Any,
@@ -298,7 +298,7 @@ def pv_files_to_pv_streams(
     and a generator of lists of PVEvents.
     :param mapping_config: Mapping application data to user data for PVEvent
     objects. Defaults to `None`
-    :type mapping_config: :class: `MappingConfig`
+    :type mapping_config: :class: `PVEventMappingConfig`
     :rtype: `Generator`[`tuple`[`str`,`Generator`[list[PVEvent]], `Any`,
     `None`]],`Any`,`None`]
     """

--- a/tel2puml/tel2puml_types.py
+++ b/tel2puml/tel2puml_types.py
@@ -148,7 +148,7 @@ class OtelPVOptions(TypedDict):
     ingest_data: bool
     save_events: bool
     find_unique_graphs: bool
-    mapping_config: PVEventMappingConfig | None
+    mapping_config: NotRequired[Optional[PVEventMappingConfig]]
 
 
 class PVPumlOptions(TypedDict):

--- a/tel2puml/tel2puml_types.py
+++ b/tel2puml/tel2puml_types.py
@@ -16,16 +16,16 @@ from pydantic import (
 from tel2puml.otel_to_pv.config import IngestDataConfig
 
 
-class MappingConfig(BaseModel):
+class PVEventMappingConfig(BaseModel):
     """Mapping configuration for PVEvent"""
 
-    jobId: str
-    eventId: str
-    timestamp: str
-    previousEventIds: str
-    applicationName: str
-    jobName: str
-    eventType: str
+    jobId: str = "jobId"
+    eventId: str = "eventId"
+    timestamp: str = "timestamp"
+    previousEventIds: str = "previousEventIds"
+    applicationName: str = "applicationName"
+    jobName: str = "jobName"
+    eventType: str = "eventType"
 
 
 class PVEvent(TypedDict):
@@ -148,7 +148,7 @@ class OtelPVOptions(TypedDict):
     ingest_data: bool
     save_events: bool
     find_unique_graphs: bool
-    mapping_config: MappingConfig | None
+    mapping_config: NotRequired[PVEventMappingConfig]
 
 
 class PVPumlOptions(TypedDict):
@@ -157,7 +157,7 @@ class PVPumlOptions(TypedDict):
     file_list: list[str]
     job_name: str
     group_by_job_id: bool
-    mapping_config: MappingConfig | None
+    mapping_config: NotRequired[PVEventMappingConfig]
 
 
 class OtelToPVArgs(BaseModel):

--- a/tel2puml/tel2puml_types.py
+++ b/tel2puml/tel2puml_types.py
@@ -148,7 +148,7 @@ class OtelPVOptions(TypedDict):
     ingest_data: bool
     save_events: bool
     find_unique_graphs: bool
-    mapping_config: NotRequired[PVEventMappingConfig]
+    mapping_config: PVEventMappingConfig | None
 
 
 class PVPumlOptions(TypedDict):

--- a/tel2puml/tel2puml_types.py
+++ b/tel2puml/tel2puml_types.py
@@ -16,6 +16,18 @@ from pydantic import (
 from tel2puml.otel_to_pv.config import IngestDataConfig
 
 
+class MappingConfig(BaseModel):
+    """Mapping configuration for PVEvent"""
+
+    jobId: str
+    eventId: str
+    timestamp: str
+    previousEventIds: str
+    applicationName: str
+    jobName: str
+    eventType: str
+
+
 class PVEvent(TypedDict):
     """A PV event"""
 
@@ -136,6 +148,7 @@ class OtelPVOptions(TypedDict):
     ingest_data: bool
     save_events: bool
     find_unique_graphs: bool
+    mapping_config: MappingConfig | None
 
 
 class PVPumlOptions(TypedDict):
@@ -144,6 +157,7 @@ class PVPumlOptions(TypedDict):
     file_list: list[str]
     job_name: str
     group_by_job_id: bool
+    mapping_config: MappingConfig | None
 
 
 class OtelToPVArgs(BaseModel):
@@ -170,6 +184,9 @@ class OtelToPVArgs(BaseModel):
         default=False,
         description="Flag indicating whether to save events to the output"
         " directory",
+    )
+    mapping_config_file: FilePath | None = Field(
+        default=None, description="Path to mapping configuration file"
     )
 
     @field_validator("config_file")
@@ -208,6 +225,9 @@ class PvToPumlArgs(BaseModel):
     )
     group_by_job: StrictBool = Field(
         default=False, description="Group events by job ID"
+    )
+    mapping_config_file: FilePath | None = Field(
+        default=None, description="Path to mapping configuration file"
     )
 
     @model_validator(mode="after")

--- a/tel2puml/tel2puml_types.py
+++ b/tel2puml/tel2puml_types.py
@@ -208,6 +208,16 @@ class OtelToPVArgs(BaseModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def check_mapping_config(self) -> Self:
+        """Check that mapping_config_file is not set when otel2puml is
+        selected."""
+        if self.command == "otel2puml" and self.mapping_config_file:
+            raise ValueError(
+                "mapping_config_file must not be set if otel2puml is selected."
+            )
+        return self
+
 
 class PvToPumlArgs(BaseModel):
     """Pydantic model for PvToPuml CLI arguments."""

--- a/tests/tel2puml/otel_to_puml/test_otel_to_puml.py
+++ b/tests/tel2puml/otel_to_puml/test_otel_to_puml.py
@@ -127,6 +127,7 @@ class TestOtelToPuml:
             "ingest_data": True,
             "save_events": False,
             "find_unique_graphs": False,
+            "mapping_config": None
         }
 
         otel_to_puml(
@@ -192,6 +193,7 @@ class TestOtelToPuml:
             "ingest_data": True,
             "save_events": False,
             "find_unique_graphs": False,
+            "mapping_config": None
         }
         # Run function
         otel_to_puml(
@@ -252,6 +254,7 @@ class TestOtelToPuml:
             "file_list": data_files,
             "job_name": "TestName",
             "group_by_job_id": group_by_job_id,
+            "mapping_config": None,
         }
 
         otel_to_puml(
@@ -312,6 +315,7 @@ class TestOtelToPuml:
             "ingest_data": True,
             "save_events": True,
             "find_unique_graphs": False,
+            "mapping_config": None,
         }
 
         otel_to_puml(
@@ -387,6 +391,7 @@ class TestOtelToPuml:
             "ingest_data": False,
             "save_events": False,
             "find_unique_graphs": True,
+            "mapping_config": None,
         }
 
         otel_to_puml(

--- a/tests/tel2puml/otel_to_puml/test_otel_to_puml.py
+++ b/tests/tel2puml/otel_to_puml/test_otel_to_puml.py
@@ -127,7 +127,6 @@ class TestOtelToPuml:
             "ingest_data": True,
             "save_events": False,
             "find_unique_graphs": False,
-            "mapping_config": None
         }
 
         otel_to_puml(
@@ -193,7 +192,6 @@ class TestOtelToPuml:
             "ingest_data": True,
             "save_events": False,
             "find_unique_graphs": False,
-            "mapping_config": None
         }
         # Run function
         otel_to_puml(
@@ -254,7 +252,6 @@ class TestOtelToPuml:
             "file_list": data_files,
             "job_name": "TestName",
             "group_by_job_id": group_by_job_id,
-            "mapping_config": None,
         }
 
         otel_to_puml(
@@ -315,7 +312,6 @@ class TestOtelToPuml:
             "ingest_data": True,
             "save_events": True,
             "find_unique_graphs": False,
-            "mapping_config": None,
         }
 
         otel_to_puml(
@@ -391,7 +387,6 @@ class TestOtelToPuml:
             "ingest_data": False,
             "save_events": False,
             "find_unique_graphs": True,
-            "mapping_config": None,
         }
 
         otel_to_puml(

--- a/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
+++ b/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
@@ -431,6 +431,46 @@ class TestSavePVEventStreamsToFile:
             # Restore permissions to delete the temp directory
             os.chmod(job_dir, 0o700)
 
+    def test_save_pv_event_stream_to_file_mapping_config_success(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that PVEvents are saved correctly to a file."""
+        job_name = "test_job"
+        pv_event: PVEvent = {
+            "jobId": "test_job_id",
+            "eventId": "1",
+            "timestamp": "2024-10-08T12:00:00Z",
+            "applicationName": "test_app",
+            "jobName": "test_job",
+            "eventType": "test_event_A",
+        }
+        pv_event_2: PVEvent = {
+            "jobId": "test_job_id",
+            "eventId": "2",
+            "timestamp": "2024-10-08T12:00:00Z",
+            "previousEventIds": ["1"],
+            "applicationName": "test_app",
+            "jobName": "test_job",
+            "eventType": "test_event_B",
+        }
+        pv_stream = (pv_event for pv_event in [pv_event, pv_event_2])
+        output_dir = tmp_path
+        count = 1
+
+        job_dir = output_dir / job_name
+        job_dir.mkdir(parents=True, exist_ok=True)
+
+        save_pv_event_stream_to_file(
+            job_name, pv_stream, str(output_dir), count, mapping_config=None
+        )
+
+        expected_file = job_dir / f"pv_event_sequence_{count}.json"
+        assert expected_file.exists()
+
+        with expected_file.open("r") as f:
+            file_content = json.load(f)
+            assert file_content == [pv_event, pv_event_2]
+
 
 class TestHandleSaveEvents:
     """Tests for the handle_save_events function."""

--- a/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
+++ b/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
@@ -9,6 +9,7 @@ import yaml
 import pytest
 import sqlalchemy as sa
 from pytest import MonkeyPatch
+from pydantic import ValidationError
 
 from tel2puml.otel_to_pv.otel_to_pv import (
     otel_to_pv,
@@ -347,7 +348,7 @@ class TestOtelToPV:
                 file_content = json.load(f)
                 assert (
                     file_content
-                    == expected_job_json_content[(2 * i): (2 * i) + 2]
+                    == expected_job_json_content[(2 * i) : (2 * i) + 2]
                 )
 
 
@@ -474,6 +475,20 @@ class TestSavePVEventStreamsToFile:
         with expected_file.open("r") as f:
             file_content = json.load(f)
             assert file_content == [expected_pv_event, expected_pv_event_2]
+
+    def test_invalid_mapping_config(self) -> None:
+        """Test that ValidationError is raised on invalid MappingConfig object
+        """
+        with pytest.raises(ValidationError):
+            MappingConfig(
+                jobIdIncorrect="jobIdNew",
+                eventId="eventIdNew",
+                timestamp="timestampNew",
+                previousEventIds="previousEventIdsNew",
+                applicationName="applicationNameNew",
+                jobName="jobNameNew",
+                eventType="eventTypeNew",
+            )
 
 
 class TestHandleSaveEvents:

--- a/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
+++ b/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
@@ -27,7 +27,7 @@ from tel2puml.otel_to_pv.otel_to_pv_types import OTelEventTypeMap
 from tel2puml.otel_to_pv.data_holders.sql_data_holder.data_model import (
     NodeModel,
 )
-from tel2puml.tel2puml_types import PVEvent, MappingConfig
+from tel2puml.tel2puml_types import PVEvent, PVEventMappingConfig
 
 
 class TestOtelToPV:
@@ -426,7 +426,7 @@ class TestSavePVEventStreamsToFile:
         self, tmp_path: Path
     ) -> None:
         """Test that PVEvents are saved correctly to a file."""
-        mapping_config = MappingConfig(
+        mapping_config = PVEventMappingConfig(
             jobId="jobIdNew",
             eventId="eventIdNew",
             timestamp="timestampNew",

--- a/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
+++ b/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
@@ -347,7 +347,7 @@ class TestOtelToPV:
                 file_content = json.load(f)
                 assert (
                     file_content
-                    == expected_job_json_content[(2 * i) : (2 * i) + 2]
+                    == expected_job_json_content[(2 * i): (2 * i) + 2]
                 )
 
 

--- a/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
+++ b/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
@@ -9,7 +9,6 @@ import yaml
 import pytest
 import sqlalchemy as sa
 from pytest import MonkeyPatch
-from pydantic import ValidationError
 
 from tel2puml.otel_to_pv.otel_to_pv import (
     otel_to_pv,

--- a/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
+++ b/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
@@ -388,6 +388,7 @@ class TestSavePVEventStreamsToFile:
             pv_stream,
             str(output_dir),
             count,
+            mapping_config=None
         )
 
         expected_file = job_dir / f"pv_event_sequence_{count}.json"
@@ -424,6 +425,7 @@ class TestSavePVEventStreamsToFile:
                     pv_stream,
                     str(output_dir),
                     count,
+                    mapping_config=None
                 )
         finally:
             # Restore permissions to delete the temp directory
@@ -476,7 +478,9 @@ class TestHandleSaveEvents:
             for stream in pv_event_streams:
                 yield (event for event in stream)
 
-        handle_save_events(job_name, event_streams_gen(), str(output_dir))
+        handle_save_events(
+            job_name, event_streams_gen(), str(output_dir), mapping_config=None
+        )
 
         job_dir = output_dir / job_name
         assert job_dir.exists() and job_dir.is_dir()
@@ -515,7 +519,10 @@ class TestHandleSaveEvents:
 
             with pytest.raises(OSError):
                 handle_save_events(
-                    job_name, event_streams_gen(), str(non_writable_dir)
+                    job_name,
+                    event_streams_gen(),
+                    str(non_writable_dir),
+                    mapping_config=None,
                 )
 
         finally:
@@ -537,7 +544,7 @@ class TestHandleSaveEvents:
             for stream in pv_event_streams:
                 yield (event for event in stream)
 
-        handle_save_events(job_name, event_streams_gen(), str(output_dir))
+        handle_save_events(job_name, event_streams_gen(), str(output_dir),mapping_config=None)
 
         job_dir = output_dir / job_name
         assert job_dir.exists() and job_dir.is_dir()

--- a/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
+++ b/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
@@ -347,7 +347,7 @@ class TestOtelToPV:
                 file_content = json.load(f)
                 assert (
                     file_content
-                    == expected_job_json_content[(2 * i): (2 * i) + 2]
+                    == expected_job_json_content[(2 * i) : (2 * i) + 2]
                 )
 
 
@@ -387,7 +387,7 @@ class TestSavePVEventStreamsToFile:
         job_dir.mkdir(parents=True, exist_ok=True)
 
         save_pv_event_stream_to_file(
-            job_name, pv_stream, str(output_dir), count, mapping_config=None
+            job_name, pv_stream, str(output_dir), count
         )
 
         expected_file = job_dir / f"pv_event_sequence_{count}.json"
@@ -412,11 +412,7 @@ class TestSavePVEventStreamsToFile:
         try:
             with pytest.raises(IOError):
                 save_pv_event_stream_to_file(
-                    job_name,
-                    pv_stream,
-                    str(output_dir),
-                    count,
-                    mapping_config=None,
+                    job_name, pv_stream, str(output_dir), count
                 )
         finally:
             # Restore permissions to delete the temp directory
@@ -522,9 +518,7 @@ class TestHandleSaveEvents:
             for stream in pv_event_streams:
                 yield (event for event in stream)
 
-        handle_save_events(
-            job_name, event_streams_gen(), str(output_dir), mapping_config=None
-        )
+        handle_save_events(job_name, event_streams_gen(), str(output_dir))
 
         job_dir = output_dir / job_name
         assert job_dir.exists() and job_dir.is_dir()
@@ -563,10 +557,7 @@ class TestHandleSaveEvents:
 
             with pytest.raises(OSError):
                 handle_save_events(
-                    job_name,
-                    event_streams_gen(),
-                    str(non_writable_dir),
-                    mapping_config=None,
+                    job_name, event_streams_gen(), str(non_writable_dir)
                 )
 
         finally:
@@ -588,9 +579,7 @@ class TestHandleSaveEvents:
             for stream in pv_event_streams:
                 yield (event for event in stream)
 
-        handle_save_events(
-            job_name, event_streams_gen(), str(output_dir), mapping_config=None
-        )
+        handle_save_events(job_name, event_streams_gen(), str(output_dir))
 
         job_dir = output_dir / job_name
         assert job_dir.exists() and job_dir.is_dir()

--- a/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
+++ b/tests/tel2puml/otel_to_pv/test_otel_to_pv.py
@@ -348,7 +348,7 @@ class TestOtelToPV:
                 file_content = json.load(f)
                 assert (
                     file_content
-                    == expected_job_json_content[(2 * i) : (2 * i) + 2]
+                    == expected_job_json_content[(2 * i): (2 * i) + 2]
                 )
 
 
@@ -475,20 +475,6 @@ class TestSavePVEventStreamsToFile:
         with expected_file.open("r") as f:
             file_content = json.load(f)
             assert file_content == [expected_pv_event, expected_pv_event_2]
-
-    def test_invalid_mapping_config(self) -> None:
-        """Test that ValidationError is raised on invalid MappingConfig object
-        """
-        with pytest.raises(ValidationError):
-            MappingConfig(
-                jobIdIncorrect="jobIdNew",
-                eventId="eventIdNew",
-                timestamp="timestampNew",
-                previousEventIds="previousEventIdsNew",
-                applicationName="applicationNameNew",
-                jobName="jobNameNew",
-                eventType="eventTypeNew",
-            )
 
 
 class TestHandleSaveEvents:

--- a/tests/tel2puml/test_pv_event_simulator.py
+++ b/tests/tel2puml/test_pv_event_simulator.py
@@ -272,6 +272,16 @@ def test_generate_test_data_event_sequences_from_puml_branch_counts() -> None:
 def test_transform_dict_into_pv_event_no_mapping_config() -> None:
     """Tests the function transform_dict_into_pv_event with no mapping config
     """
+    def validate_pv_event(pv_event: PVEvent, prev_id: bool) -> None:
+        assert isinstance(pv_event, dict)
+        assert pv_event["eventId"] == "event_test"
+        assert pv_event["eventType"] == "eventType_test"
+        assert pv_event["jobId"] == "jobId_test"
+        assert pv_event["timestamp"] == "timestamp_test"
+        assert pv_event["applicationName"] == "applicationName_test"
+        assert pv_event["jobName"] == "jobName_test"
+        if prev_id:
+            assert pv_event["previousEventIds"] == ["1"]
     # Test 1: Successful transformation no previous_event_id
     pv_event_dict: dict[str, Any] = {
         "eventId": "event_test",
@@ -283,13 +293,7 @@ def test_transform_dict_into_pv_event_no_mapping_config() -> None:
     }
 
     pv_event = transform_dict_into_pv_event(pv_event_dict)
-    assert isinstance(pv_event, dict)
-    assert pv_event["eventId"]=="event_test"
-    assert pv_event["eventType"]=="eventType_test"
-    assert pv_event["jobId"] == "jobId_test"
-    assert pv_event["timestamp"] == "timestamp_test"
-    assert pv_event["applicationName"] == "applicationName_test"
-    assert pv_event["jobName"]=="jobName_test"
+    validate_pv_event(pv_event, False)
 
     # Test 2: Successful transformation previous_event_id as string
     pv_event_dict = {
@@ -303,14 +307,7 @@ def test_transform_dict_into_pv_event_no_mapping_config() -> None:
     }
 
     pv_event = transform_dict_into_pv_event(pv_event_dict)
-    assert isinstance(pv_event, dict)
-    assert pv_event["eventId"] == "event_test"
-    assert pv_event["eventType"] == "eventType_test"
-    assert pv_event["jobId"] == "jobId_test"
-    assert pv_event["timestamp"] == "timestamp_test"
-    assert pv_event["applicationName"] == "applicationName_test"
-    assert pv_event["jobName"] == "jobName_test"
-    assert pv_event["previousEventIds"] == ["1"]
+    validate_pv_event(pv_event, True)
 
     # Test 3: Successful transformation previous_event_id as list
     pv_event_dict = {
@@ -324,14 +321,7 @@ def test_transform_dict_into_pv_event_no_mapping_config() -> None:
     }
 
     pv_event = transform_dict_into_pv_event(pv_event_dict)
-    assert isinstance(pv_event, dict)
-    assert pv_event["eventId"] == "event_test"
-    assert pv_event["eventType"] == "eventType_test"
-    assert pv_event["jobId"] == "jobId_test"
-    assert pv_event["timestamp"] == "timestamp_test"
-    assert pv_event["applicationName"] == "applicationName_test"
-    assert pv_event["jobName"] == "jobName_test"
-    assert pv_event["previousEventIds"] == ["1"]
+    validate_pv_event(pv_event, True)
 
     # Test 4: Incorrect mandatory field
     pv_event_dict = {
@@ -348,6 +338,17 @@ def test_transform_dict_into_pv_event_no_mapping_config() -> None:
 
 def test_transform_dict_into_pv_event_with_mapping_config() -> None:
     """Tests the function transform_dict_into_pv_event with mapping config"""
+    def validate_pv_event(pv_event: PVEvent, prev_id: bool) -> None:
+        assert isinstance(pv_event, dict)
+        assert pv_event["eventId"] == "event_test"
+        assert pv_event["eventType"] == "eventType_test"
+        assert pv_event["jobId"] == "jobId_test"
+        assert pv_event["timestamp"] == "timestamp_test"
+        assert pv_event["applicationName"] == "applicationName_test"
+        assert pv_event["jobName"] == "jobName_test"
+        if prev_id:
+            assert pv_event["previousEventIds"] == ["1"]
+
     # mapping config used for all tests
     mapping_config = MappingConfig(
         jobId="jobIdNew",
@@ -371,13 +372,7 @@ def test_transform_dict_into_pv_event_with_mapping_config() -> None:
     pv_event = transform_dict_into_pv_event(
         pv_event_dict, mapping_config=mapping_config
     )
-    assert isinstance(pv_event, dict)
-    assert pv_event["eventId"] == "event_test"
-    assert pv_event["eventType"] == "eventType_test"
-    assert pv_event["jobId"] == "jobId_test"
-    assert pv_event["timestamp"] == "timestamp_test"
-    assert pv_event["applicationName"] == "applicationName_test"
-    assert pv_event["jobName"] == "jobName_test"
+    validate_pv_event(pv_event, False)
 
     # Test 2: Successful transformation previous_event_id as string
     pv_event_dict = {
@@ -393,14 +388,7 @@ def test_transform_dict_into_pv_event_with_mapping_config() -> None:
     pv_event = transform_dict_into_pv_event(
         pv_event_dict, mapping_config=mapping_config
     )
-    assert isinstance(pv_event, dict)
-    assert pv_event["eventId"] == "event_test"
-    assert pv_event["eventType"] == "eventType_test"
-    assert pv_event["jobId"] == "jobId_test"
-    assert pv_event["timestamp"] == "timestamp_test"
-    assert pv_event["applicationName"] == "applicationName_test"
-    assert pv_event["jobName"] == "jobName_test"
-    assert pv_event["previousEventIds"] == ["1"]
+    validate_pv_event(pv_event, True)
 
     # Test 3: Successful transformation previous_event_id as list
     pv_event_dict = {
@@ -416,14 +404,7 @@ def test_transform_dict_into_pv_event_with_mapping_config() -> None:
     pv_event = transform_dict_into_pv_event(
         pv_event_dict, mapping_config=mapping_config
     )
-    assert isinstance(pv_event, dict)
-    assert pv_event["eventId"] == "event_test"
-    assert pv_event["eventType"] == "eventType_test"
-    assert pv_event["jobId"] == "jobId_test"
-    assert pv_event["timestamp"] == "timestamp_test"
-    assert pv_event["applicationName"] == "applicationName_test"
-    assert pv_event["jobName"] == "jobName_test"
-    assert pv_event["previousEventIds"] == ["1"]
+    validate_pv_event(pv_event, True)
 
     # Test 4: Incorrect mandatory field
     pv_event_dict = {

--- a/tests/tel2puml/test_pv_event_simulator.py
+++ b/tests/tel2puml/test_pv_event_simulator.py
@@ -13,7 +13,7 @@ from tel2puml.pv_event_simulator import (
     Job,
     transform_dict_into_pv_event,
 )
-from tel2puml.tel2puml_types import PVEvent, MappingConfig
+from tel2puml.tel2puml_types import PVEvent, PVEventMappingConfig
 
 
 class TestJob:
@@ -355,7 +355,7 @@ def test_transform_dict_into_pv_event_with_mapping_config() -> None:
             assert pv_event["previousEventIds"] == ["1"]
 
     # mapping config used for all tests
-    mapping_config = MappingConfig(
+    mapping_config = PVEventMappingConfig(
         jobId="jobIdNew",
         eventId="eventIdNew",
         timestamp="timestampNew",

--- a/tests/tel2puml/test_pv_event_simulator.py
+++ b/tests/tel2puml/test_pv_event_simulator.py
@@ -1,4 +1,5 @@
 """tests for module test_data_creation.py"""
+
 from typing import Any
 
 import pytest
@@ -17,6 +18,7 @@ from tel2puml.tel2puml_types import PVEvent, MappingConfig
 
 class TestJob:
     """Test class for Job"""
+
     def input_job(self) -> list[PVEvent]:
         """Returns a list of PVEvent objects"""
         return [
@@ -34,9 +36,7 @@ class TestJob:
 
     def input_job_with_dict(self) -> list[dict[str, Any]]:
         """Returns a list of dictionaries representing PVEvent objects"""
-        return [
-            {**event} for event in self.input_job()
-        ]
+        return [{**event} for event in self.input_job()]
 
     def test_init(self) -> None:
         """tests for Job.__init__"""
@@ -272,6 +272,7 @@ def test_generate_test_data_event_sequences_from_puml_branch_counts() -> None:
 def test_transform_dict_into_pv_event_no_mapping_config() -> None:
     """Tests the function transform_dict_into_pv_event with no mapping config
     """
+
     def validate_pv_event(pv_event: PVEvent, prev_id: bool) -> None:
         """Helper function to validate pv_event"""
         assert isinstance(pv_event, dict)
@@ -283,6 +284,7 @@ def test_transform_dict_into_pv_event_no_mapping_config() -> None:
         assert pv_event["jobName"] == "jobName_test"
         if prev_id:
             assert pv_event["previousEventIds"] == ["1"]
+
     # Test 1: Successful transformation no previous_event_id
     pv_event_dict: dict[str, Any] = {
         "eventId": "event_test",
@@ -304,7 +306,7 @@ def test_transform_dict_into_pv_event_no_mapping_config() -> None:
         "timestamp": "timestamp_test",
         "applicationName": "applicationName_test",
         "jobName": "jobName_test",
-        "previousEventIds": "1"
+        "previousEventIds": "1",
     }
 
     pv_event = transform_dict_into_pv_event(pv_event_dict)
@@ -339,6 +341,7 @@ def test_transform_dict_into_pv_event_no_mapping_config() -> None:
 
 def test_transform_dict_into_pv_event_with_mapping_config() -> None:
     """Tests the function transform_dict_into_pv_event with mapping config"""
+
     def validate_pv_event(pv_event: PVEvent, prev_id: bool) -> None:
         """Helper function to validate pv_event"""
         assert isinstance(pv_event, dict)
@@ -418,4 +421,6 @@ def test_transform_dict_into_pv_event_with_mapping_config() -> None:
         "jobNameNew": "jobName_test",
     }
     with pytest.raises(ValueError):
-        pv_event = transform_dict_into_pv_event(pv_event_dict, mapping_config=mapping_config)
+        pv_event = transform_dict_into_pv_event(
+            pv_event_dict, mapping_config=mapping_config
+        )

--- a/tests/tel2puml/test_pv_event_simulator.py
+++ b/tests/tel2puml/test_pv_event_simulator.py
@@ -273,6 +273,7 @@ def test_transform_dict_into_pv_event_no_mapping_config() -> None:
     """Tests the function transform_dict_into_pv_event with no mapping config
     """
     def validate_pv_event(pv_event: PVEvent, prev_id: bool) -> None:
+        """Helper function to validate pv_event"""
         assert isinstance(pv_event, dict)
         assert pv_event["eventId"] == "event_test"
         assert pv_event["eventType"] == "eventType_test"
@@ -339,6 +340,7 @@ def test_transform_dict_into_pv_event_no_mapping_config() -> None:
 def test_transform_dict_into_pv_event_with_mapping_config() -> None:
     """Tests the function transform_dict_into_pv_event with mapping config"""
     def validate_pv_event(pv_event: PVEvent, prev_id: bool) -> None:
+        """Helper function to validate pv_event"""
         assert isinstance(pv_event, dict)
         assert pv_event["eventId"] == "event_test"
         assert pv_event["eventType"] == "eventType_test"

--- a/tests/tel2puml/test_pv_event_simulator.py
+++ b/tests/tel2puml/test_pv_event_simulator.py
@@ -10,8 +10,9 @@ from tel2puml.pv_event_simulator import (
     generate_test_data,
     generate_test_data_event_sequences_from_puml,
     Job,
+    transform_dict_into_pv_event,
 )
-from tel2puml.tel2puml_types import PVEvent
+from tel2puml.tel2puml_types import PVEvent, MappingConfig
 
 
 class TestJob:
@@ -266,3 +267,172 @@ def test_generate_test_data_event_sequences_from_puml_branch_counts() -> None:
         assert num_c in expected_numbers_of_event_c
         expected_numbers_of_event_c.remove(num_c)
     assert len(expected_numbers_of_event_c) == 0
+
+
+def test_transform_dict_into_pv_event_no_mapping_config() -> None:
+    """Tests the function transform_dict_into_pv_event with no mapping config
+    """
+    # Test 1: Successful transformation no previous_event_id
+    pv_event_dict = {
+        "eventId": "event_test",
+        "eventType": "eventType_test",
+        "jobId": "jobId_test",
+        "timestamp": "timestamp_test",
+        "applicationName": "applicationName_test",
+        "jobName": "jobName_test",
+    }
+
+    pv_event = transform_dict_into_pv_event(pv_event_dict)
+    assert isinstance(pv_event, dict)
+    assert pv_event["eventId"]=="event_test"
+    assert pv_event["eventType"]=="eventType_test"
+    assert pv_event["jobId"] == "jobId_test"
+    assert pv_event["timestamp"] == "timestamp_test"
+    assert pv_event["applicationName"] == "applicationName_test"
+    assert pv_event["jobName"]=="jobName_test"
+
+    # Test 2: Successful transformation previous_event_id as string
+    pv_event_dict = {
+        "eventId": "event_test",
+        "eventType": "eventType_test",
+        "jobId": "jobId_test",
+        "timestamp": "timestamp_test",
+        "applicationName": "applicationName_test",
+        "jobName": "jobName_test",
+        "previousEventIds": "1"
+    }
+
+    pv_event = transform_dict_into_pv_event(pv_event_dict)
+    assert isinstance(pv_event, dict)
+    assert pv_event["eventId"] == "event_test"
+    assert pv_event["eventType"] == "eventType_test"
+    assert pv_event["jobId"] == "jobId_test"
+    assert pv_event["timestamp"] == "timestamp_test"
+    assert pv_event["applicationName"] == "applicationName_test"
+    assert pv_event["jobName"] == "jobName_test"
+    assert pv_event["previousEventIds"] == ["1"]
+
+    # Test 3: Successful transformation previous_event_id as list
+    pv_event_dict = {
+        "eventId": "event_test",
+        "eventType": "eventType_test",
+        "jobId": "jobId_test",
+        "timestamp": "timestamp_test",
+        "applicationName": "applicationName_test",
+        "jobName": "jobName_test",
+        "previousEventIds": ["1"],
+    }
+
+    pv_event = transform_dict_into_pv_event(pv_event_dict)
+    assert isinstance(pv_event, dict)
+    assert pv_event["eventId"] == "event_test"
+    assert pv_event["eventType"] == "eventType_test"
+    assert pv_event["jobId"] == "jobId_test"
+    assert pv_event["timestamp"] == "timestamp_test"
+    assert pv_event["applicationName"] == "applicationName_test"
+    assert pv_event["jobName"] == "jobName_test"
+    assert pv_event["previousEventIds"] == ["1"]
+
+    # Test 4: Incorrect mandatory field
+    pv_event_dict = {
+        "eventId": "event_test",
+        "IncorrectField": "eventType_test",
+        "jobId": "jobId_test",
+        "timestamp": "timestamp_test",
+        "applicationName": "applicationName_test",
+        "jobName": "jobName_test",
+    }
+    with pytest.raises(ValueError):
+        pv_event = transform_dict_into_pv_event(pv_event_dict)
+
+
+def test_transform_dict_into_pv_event_with_mapping_config() -> None:
+    """Tests the function transform_dict_into_pv_event with mapping config"""
+    # mapping config used for all tests
+    mapping_config = MappingConfig(
+        jobId="jobIdNew",
+        eventId="eventIdNew",
+        timestamp="timestampNew",
+        previousEventIds="previousEventIdsNew",
+        applicationName="applicationNameNew",
+        jobName="jobNameNew",
+        eventType="eventTypeNew",
+    )
+    # Test 1: Successful transformation no previous_event_id
+    pv_event_dict = {
+        "eventIdNew": "event_test",
+        "eventTypeNew": "eventType_test",
+        "jobIdNew": "jobId_test",
+        "timestampNew": "timestamp_test",
+        "applicationNameNew": "applicationName_test",
+        "jobNameNew": "jobName_test",
+    }
+
+    pv_event = transform_dict_into_pv_event(
+        pv_event_dict, mapping_config=mapping_config
+    )
+    assert isinstance(pv_event, dict)
+    assert pv_event["eventId"] == "event_test"
+    assert pv_event["eventType"] == "eventType_test"
+    assert pv_event["jobId"] == "jobId_test"
+    assert pv_event["timestamp"] == "timestamp_test"
+    assert pv_event["applicationName"] == "applicationName_test"
+    assert pv_event["jobName"] == "jobName_test"
+
+    # Test 2: Successful transformation previous_event_id as string
+    pv_event_dict = {
+        "eventIdNew": "event_test",
+        "eventTypeNew": "eventType_test",
+        "jobIdNew": "jobId_test",
+        "timestampNew": "timestamp_test",
+        "applicationNameNew": "applicationName_test",
+        "jobNameNew": "jobName_test",
+        "previousEventIdsNew": "1",
+    }
+
+    pv_event = transform_dict_into_pv_event(
+        pv_event_dict, mapping_config=mapping_config
+    )
+    assert isinstance(pv_event, dict)
+    assert pv_event["eventId"] == "event_test"
+    assert pv_event["eventType"] == "eventType_test"
+    assert pv_event["jobId"] == "jobId_test"
+    assert pv_event["timestamp"] == "timestamp_test"
+    assert pv_event["applicationName"] == "applicationName_test"
+    assert pv_event["jobName"] == "jobName_test"
+    assert pv_event["previousEventIds"] == ["1"]
+
+    # Test 3: Successful transformation previous_event_id as list
+    pv_event_dict = {
+        "eventIdNew": "event_test",
+        "eventTypeNew": "eventType_test",
+        "jobIdNew": "jobId_test",
+        "timestampNew": "timestamp_test",
+        "applicationNameNew": "applicationName_test",
+        "jobNameNew": "jobName_test",
+        "previousEventIdsNew": ["1"],
+    }
+
+    pv_event = transform_dict_into_pv_event(
+        pv_event_dict, mapping_config=mapping_config
+    )
+    assert isinstance(pv_event, dict)
+    assert pv_event["eventId"] == "event_test"
+    assert pv_event["eventType"] == "eventType_test"
+    assert pv_event["jobId"] == "jobId_test"
+    assert pv_event["timestamp"] == "timestamp_test"
+    assert pv_event["applicationName"] == "applicationName_test"
+    assert pv_event["jobName"] == "jobName_test"
+    assert pv_event["previousEventIds"] == ["1"]
+
+    # Test 4: Incorrect mandatory field
+    pv_event_dict = {
+        "eventIdNew": "event_test",
+        "IncorrectField": "eventType_test",
+        "jobIdNew": "jobId_test",
+        "timestampNew": "timestamp_test",
+        "applicationNameNew": "applicationName_test",
+        "jobNameNew": "jobName_test",
+    }
+    with pytest.raises(ValueError):
+        pv_event = transform_dict_into_pv_event(pv_event_dict, mapping_config=mapping_config)

--- a/tests/tel2puml/test_pv_event_simulator.py
+++ b/tests/tel2puml/test_pv_event_simulator.py
@@ -273,7 +273,7 @@ def test_transform_dict_into_pv_event_no_mapping_config() -> None:
     """Tests the function transform_dict_into_pv_event with no mapping config
     """
     # Test 1: Successful transformation no previous_event_id
-    pv_event_dict = {
+    pv_event_dict: dict[str, Any] = {
         "eventId": "event_test",
         "eventType": "eventType_test",
         "jobId": "jobId_test",
@@ -359,7 +359,7 @@ def test_transform_dict_into_pv_event_with_mapping_config() -> None:
         eventType="eventTypeNew",
     )
     # Test 1: Successful transformation no previous_event_id
-    pv_event_dict = {
+    pv_event_dict: dict[str, Any] = {
         "eventIdNew": "event_test",
         "eventTypeNew": "eventType_test",
         "jobIdNew": "jobId_test",


### PR DESCRIPTION
This PR introduces support for specifying a custom mapping_config.yaml file in the tel2puml CLI tool. It adds the ability to map application-specific data fields to PVEvent fields via the --mapping-config or -mc flag, ensuring flexibility when dealing with non-standard data structures.