### PR TITLE
219 config file validation when dirpath and filepath are both populated with valid entries

### DIFF
--- a/docs/user/Config.md
+++ b/docs/user/Config.md
@@ -25,7 +25,7 @@ data_holders:
 data_sources:
     json:
         dirpath: /path/to/json/directory
-        filepath: /path/to/json/file.json
+        filepath: null
         json_per_line: false
         field_mapping: <field mapping config>
 sequencer: <sequencer config>
@@ -50,8 +50,8 @@ This section contains the configuration for the data holders. The following opti
 ### `data_sources`
 This section contains the configuration for the data sources. The following options are available:
 * `json`: The configuration for the JSON data source. The following options are available:
-    * `dirpath`: The path to the directory containing the JSON files. This is required if `filepath` is not provided.
-    * `filepath`: The path to the JSON file. This is required if `dirpath` is not provided.
+    * `dirpath`: The path to the directory containing the JSON files. This is required if `filepath` is not provided and cannot be used in conjunction with `filepath`.
+    * `filepath`: The path to the JSON file. This is required if `dirpath` is not provided and cannot be used in conjunction with `dirpath`.
     * `json_per_line`: A boolean value indicating whether each line in the JSON file is a separate JSON object. The default value is `false`.
     * `field_mapping`: The field mapping configuration. The details of how this is used can be found in the [JSON Data Converter HOW TO](/docs/user/json_data_converter_HOWTO.md) section. This is required if `jq_query` is not provided and cannot be used in conjunction with `jq_query`.
     * `jq_query`: A jq query to use to extract the data from the JSON file. This is required if `field_mapping` is not provided and cannot be used in conjunction with `field_mapping`. The jq query should return objects representing single events ([OTel Event](/docs/user/json_data_converter_HOWTO.md#1-introduction)). JQ usage can be found at https://jqlang.github.io/jq/.

--- a/tel2puml/otel_to_pv/data_sources/json_data_source/json_config.py
+++ b/tel2puml/otel_to_pv/data_sources/json_data_source/json_config.py
@@ -12,18 +12,12 @@ class FieldSpec(TypedDict):
     key_paths: Union[Sequence[str | Iterable[str]], str]
     key_value: NotRequired[
         Optional[
-            Union[
-                Sequence[Optional[Union[str, Iterable[str | None]]]],
-                str
-            ]
+            Union[Sequence[Optional[Union[str, Iterable[str | None]]]], str]
         ]
     ]
     value_paths: NotRequired[
         Optional[
-            Union[
-                Sequence[Optional[Union[str, Iterable[str | None]]]],
-                str
-            ]
+            Union[Sequence[Optional[Union[str, Iterable[str | None]]]], str]
         ]
     ]
     value_type: str
@@ -209,10 +203,7 @@ class JQFieldSpec:
     @staticmethod
     def optional_list_to_jq_optional_list(
         optional_list: Optional[
-            Union[
-                Sequence[Optional[Union[str, Iterable[str | None]]]],
-                str
-            ]
+            Union[Sequence[Optional[Union[str, Iterable[str | None]]]], str]
         ],
         jq_key_paths: Sequence[tuple[str, ...]],
     ) -> list[tuple[str | None, ...]]:
@@ -306,6 +297,7 @@ def field_spec_mapping_to_jq_field_spec_mapping(
 class OTelFieldMapping(BaseModel):
     """BaseModel for OTelFieldMapping - the expected mapping of fields in the
     used for the JSON data source."""
+
     job_name: FieldSpec
     job_id: FieldSpec
     event_type: FieldSpec
@@ -371,4 +363,8 @@ class JSONDataSourceConfig(BaseModel):
         """Verify file path dir path."""
         if self.filepath is None and self.dirpath is None:
             raise ValueError("Either filepath or dirpath must be provided")
+        if self.filepath is not None and self.dirpath is not None:
+            raise ValueError(
+                "Only one of filepath or dirpath should be provided"
+            )
         return self

--- a/tests/tel2puml/main/conftest.py
+++ b/tests/tel2puml/main/conftest.py
@@ -21,7 +21,7 @@ def mock_yaml_config_file(tmp_path: Path) -> Path:
         "data_sources": {
             "json": {
                 "dirpath": "/path/to/json/directory",
-                "filepath": "/path/to/json/file.json",
+                "filepath": None,
                 "json_per_line": False,
                 "field_mapping": {
                     "job_name": {

--- a/tests/tel2puml/otel_to_pv/conftest.py
+++ b/tests/tel2puml/otel_to_pv/conftest.py
@@ -37,7 +37,7 @@ def mock_yaml_config_string() -> str:
             data_sources:
                 json:
                     dirpath: /path/to/json/directory
-                    filepath: /path/to/json/file.json
+                    filepath: null
                     json_per_line: false
                     jq_query: null
                     field_mapping:

--- a/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_config.py
+++ b/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_config.py
@@ -396,7 +396,7 @@ class TestJSONDataSourceConfig:
             config_dict = dict(
                 field_mapping=case_2[0],
                 filepath="filepath",
-                dirpath="dirpath",
+                dirpath=None,
                 json_per_line=False,
                 jq_query=case_2[1],
             )
@@ -411,7 +411,7 @@ class TestJSONDataSourceConfig:
             assert config.jq_query == case_2[1]
             assert not config.json_per_line
             assert config.filepath == "filepath"
-            assert config.dirpath == "dirpath"
+            assert config.dirpath is None
         # test case negative cases of incorrect types
         for case_3 in [
             "field_mapping",
@@ -423,7 +423,7 @@ class TestJSONDataSourceConfig:
             input_dict: dict[str, Any] = dict(
                 field_mapping=field_mapping,
                 filepath="filepath",
-                dirpath="dirpath",
+                dirpath=None,
                 json_per_line=True,
                 jq_query=None,
             )
@@ -435,7 +435,7 @@ class TestJSONDataSourceConfig:
             JSONDataSourceConfig(
                 field_mapping=None,
                 filepath="filepath",
-                dirpath="dirpath",
+                dirpath=None,
                 json_per_line=True,
                 jq_query=None,
             )
@@ -444,7 +444,7 @@ class TestJSONDataSourceConfig:
             config_dict = dict(
                 field_mapping=field_mapping,
                 filepath="filepath",
-                dirpath="dirpath",
+                dirpath=None,
                 json_per_line=True,
                 jq_query="jq_query",
             )
@@ -457,6 +457,18 @@ class TestJSONDataSourceConfig:
                 field_mapping=field_mapping,
                 filepath=None,
                 dirpath=None,
+                json_per_line=True,
+                jq_query=None,
+            )
+            JSONDataSourceConfig(
+                **config_dict
+            )
+        # test case where both file path and dir path are provided
+        with pytest.raises(ValidationError):
+            config_dict = dict(
+                field_mapping=field_mapping,
+                filepath="filepath",
+                dirpath="dirpath",
                 json_per_line=True,
                 jq_query=None,
             )

--- a/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_jq_converter.py
+++ b/tests/tel2puml/otel_to_pv/data_sources/json_data_source/test_json_jq_converter.py
@@ -606,7 +606,7 @@ def test_get_jq_query_from_config(monkeypatch: MonkeyPatch) -> None:
     # test case where jq query is provided
     config = JSONDataSourceConfig(
         field_mapping=None,
-        filepath="filepath",
+        filepath=None,
         dirpath="dirpath",
         json_per_line=False,
         jq_query="jq_query",
@@ -627,7 +627,7 @@ def test_get_jq_query_from_config(monkeypatch: MonkeyPatch) -> None:
                 "parent_event_id",
             ]
         },
-        "filepath": "filepath",
+        "filepath": None,
         "dirpath": "dirpath",
         "json_per_line": False,
         "jq_query": None,

--- a/tests/tel2puml/otel_to_pv/test_ingest_otel_data.py
+++ b/tests/tel2puml/otel_to_pv/test_ingest_otel_data.py
@@ -155,7 +155,7 @@ def test_fetch_data_source(mock_ingest_config: IngestDataConfig) -> None:
     data_source = fetch_data_source(mock_ingest_config)
     assert isinstance(data_source, JSONDataSource)
     assert data_source.dirpath == "/path/to/json/directory"
-    assert data_source.filepath == "/path/to/json/file.json"
+    assert data_source.filepath is None
 
 
 @pytest.mark.usefixtures("mock_path_exists", "mock_filepath_in_dir")


### PR DESCRIPTION
PR to update the solution to make sure dirpath and filepath cannot be used in conjunction with one another for user experience