### PR TITLE
229 help text pv2puml the text cannot be used with file paths is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,13 +343,13 @@ python -m tel2puml pv2puml [options] [FILE_PATHS...]
 - `-fp`, `--folder-path`: Path to a folder containing job JSON files (PV Event JSONs in array's). Cannot be used with `FILE_PATHS`.
 - `FILE_PATHS`: One or more files containing job JSON (PV Event JSON arrays) array data. Cannot be used with `-fp`.
 - `-jn`, `--job-name`: Name for the PlantUML sequence diagram and output file prefix (default is `"default_name"`).
-- `-group-by-job`: Group events by job ID.
+- `-group-by-job`: Group events by job ID. Can only be used if there are single events in each input file otherwise an error will be raised.
 - `-mc`, `--mapping-config`: Path to the mapping configuration file. [Usage](docs/user/mapping_config.md)
 
 **Notes:**
 
 - You must provide either `-fp` or `FILE_PATHS`, but not both.
-- The `-group-by-job` option is useful when you have events from multiple jobs and want to separate them in the diagram.
+- The `-group-by-job` option is used when you have single events in files and you need to group them by `job_id` (into event sequences).
 
 **Examples:**
 

--- a/tel2puml/__main__.py
+++ b/tel2puml/__main__.py
@@ -157,7 +157,10 @@ pv_to_puml_parser.add_argument(
 
 pv_to_puml_parser.add_argument(
     "-group-by-job",
-    help="Group events by job ID",
+    help=(
+        "Group events by job ID. Can only be used if there are single events "
+        "in each input file otherwise an error will be raised"
+    ),
     action="store_true",
     dest="group_by_job",
 )

--- a/tel2puml/__main__.py
+++ b/tel2puml/__main__.py
@@ -125,7 +125,10 @@ pv_exclusive_group.add_argument(
     "-fp",
     "--folder-path",
     metavar="dir",
-    help="Path to folder containing job json files",
+    help=(
+        "Path to folder containing job json files. Cannot be used with option "
+        "file_paths"
+    ),
     dest="folder_path",
     required=False,
 )
@@ -133,7 +136,10 @@ pv_exclusive_group.add_argument(
 pv_exclusive_group.add_argument(
     "file_paths",
     nargs="*",
-    help="Input files containing job data in json format",
+    help=(
+        "Input files containing job data in json format. Cannot be used with "
+        "option --folder-path"
+    ),
     default=[],
 )
 


### PR DESCRIPTION
Fix  CLI help for pv to puml -fp option and file_paths option

Also updated information on `group-by-job` option to provide extra information.