### PR TITLE
265 inputoutput base model graphs for pv2puml

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ This project converts [OpenTelemetry (OTel)](https://opentelemetry.io/) data int
       </ol>
     </li>
     <li><a href="#tel2puml-cli-documentation">TEL2PUML CLI Documentation</a></li>
-    <li><a href="#technical-implementation">Technical Implementtation</a></li>
+    <li><a href="#technical-implementation">Technical Implementation</a></li>
+    <li><a href="#best-practices">Best Practices</a></li>
     <li><a href="#documentation">Documentation</a></li>
     <li><a href="#dependencies">Dependencies</a></li>
     <li><a href="#contributing">Contributing</a></li>
@@ -420,6 +421,13 @@ python -m tel2puml [subcommand] -h
 ```bash
 python -m tel2puml pv2puml -h
 ```
+
+## Best Practices
+
+- The tool was initially designed to work with OpenTelemetry data, but can in principle be used for any data that is a call tree with information of parents links and timestamps. Ensure that your data is in the correct format before running the tool.
+- When ingesting data using the `otel2pv` or `otel2puml` subcommands, the data is stored in a SQL database provided by the user. There are some SQL functions that are used to map data from the root node to the leaf nodes. For large sizes of data, this can take a long time and may require a large amount of memory. The best way to avoid this is to chunk the data into smaller sizes (making sure that the min and max timestamps of the chunks do not overlap) and ingest it in smaller parts either:
+    - For `otel2puml` command by using the `-om` and `-im` args to save models and then load the models to the next chunk.
+    - For `otel2pv` by using the `-ug` flag to find the unique event sequences and then `-se` to save the event sequences. Once this is done all of the event sequences can be loaded used with the `pv2puml` command to find the PUML's.
 
 ## Technical Implementation
 

--- a/README.md
+++ b/README.md
@@ -321,8 +321,8 @@ python -m tel2puml -o OUTPUT_DIR otel2puml -c CONFIG_FILE [options]
 - `-ni`, `--no-ingest`: Do not load data into the data holder.
 - `-ug`, `--unique-graphs`: Find unique graphs within the data holder.
 - `-d`, `--debug`: Enable debug mode to view full error stack trace.
-- `-im`, `--input-puml-models`: Path to an input puml model. Can be used multiple times for each model the user wishes to input.
-- `-om`, `--output-puml-models`: Flag to indicate whether to output the puml models. If this flag is not set, the puml models will not be output.
+- `-im`, `--input-puml-models`: Path to an input puml model. Can be used multiple times for each model the user wishes to input. [Usage](/docs/user/PUML_models.md)
+- `-om`, `--output-puml-models`: Flag to indicate whether to output the puml models. If this flag is not set, the puml models will not be output. [Usage](/docs/user/PUML_models.md)
 
 **Example:**
 
@@ -373,8 +373,8 @@ python -m tel2puml pv2puml [options] [FILE_PATHS...]
 - `-group-by-job`: Group events by job ID. Can only be used if there are single events in each input file otherwise an error will be raised.
 - `-mc`, `--mapping-config`: Path to the mapping configuration file. [Usage](docs/user/mapping_config.md)
 - `-d`, `--debug`: Enable debug mode to view full error stack trace.
-- `-im`, `--input-puml-models`: Path to an input puml model. Can be used multiple times for each model the user wishes to input.
-- `-om`, `--output-puml-models`: Flag to indicate whether to output the puml models. If this flag is not set, the puml models will not be output.
+- `-im`, `--input-puml-models`: Path to an input puml model. Can be used multiple times for each model the user wishes to input. [Usage](/docs/user/PUML_models.md)
+- `-om`, `--output-puml-models`: Flag to indicate whether to output the puml models. If this flag is not set, the puml models will not be output. [Usage](/docs/user/PUML_models.md)
 
 **Notes:**
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ python -m tel2puml -o OUTPUT_DIR otel2puml -c CONFIG_FILE [options]
 - `-ni`, `--no-ingest`: Do not load data into the data holder.
 - `-ug`, `--unique-graphs`: Find unique graphs within the data holder.
 - `-d`, `--debug`: Enable debug mode to view full error stack trace.
+- `-im`, `--input-puml-models`: Path to an input puml model. Can be used multiple times for each model the user wishes to input.
+- `-om`, `--output-puml-models`: Flag to indicate whether to output the puml models. If this flag is not set, the puml models will not be output.
 
 **Example:**
 
@@ -371,6 +373,8 @@ python -m tel2puml pv2puml [options] [FILE_PATHS...]
 - `-group-by-job`: Group events by job ID. Can only be used if there are single events in each input file otherwise an error will be raised.
 - `-mc`, `--mapping-config`: Path to the mapping configuration file. [Usage](docs/user/mapping_config.md)
 - `-d`, `--debug`: Enable debug mode to view full error stack trace.
+- `-im`, `--input-puml-models`: Path to an input puml model. Can be used multiple times for each model the user wishes to input.
+- `-om`, `--output-puml-models`: Flag to indicate whether to output the puml models. If this flag is not set, the puml models will not be output.
 
 **Notes:**
 

--- a/docs/user/PUML_models.md
+++ b/docs/user/PUML_models.md
@@ -1,0 +1,189 @@
+# PUML Models
+## Introdcution
+Internally `tel2puml` uses a model that it builds from event sequences that are passed into it. This model is built with the following components:
+
+
+- **EventSet** - This is a unique "set" of `eventTypes` and their counts e.g., `A: 3, B: 2, C: 1`. This is used to represent a single possibility specific events and their occurence 
+- **Event**: Represents a single event with:
+    - `eventType` - e.g., `A`, `B`, `C`, etc.
+    - `outgoingEventSets` - This is a list of `EventSet` objects that represent the possible next events that can occur after this event with a forward connection.
+    - `incomingEventSets` - This is a list of `EventSet` objects that represent the possible previous events that can occur before this event with a backwards connection.
+- **EventModel**: This is the main model that is built from the event sequences. It contains a list of `Event` objects that represent the events in the sequence. It also contains a list of `EventSet` objects that represent the possible event sets that can occur in the sequence.
+
+Functionality is present in tel2puml to input and save these "models" as JSON files. Saved models can be loaded back into the tool to be updated with new event sequences. This can provide a way to build up a model over time as more event sequences are collected or in the circumstances that there are large volumes of data that need to be processed.
+
+## Model JSON file format
+The model file is provided as a specific JSON file format. This file format is used to save the model that is built from the event sequences. It should be noted that there will always be a "Dummy" starting event added with `eventType` of `|||START|||` to represent the start of the sequence. This is added to ensure that all events have a starting point so that logic can be derived even for multiple starting points in the actual data.
+
+The JSON file format has the following JSON schema
+
+```json
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "job_name": {
+            "type": "string"
+        },
+        "events": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "eventType": {
+                        "type": "string"
+                    },
+                    "outgoingEventSets": {
+                        "type": "array",
+                        "items": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "eventType": {
+                                        "type": "string"
+                                    },
+                                    "count": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "count",
+                                    "eventType"
+                                ]
+                            }
+                        }
+                    },
+                    "incomingEventSets": {
+                        "type": "array",
+                        "items": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "eventType": {
+                                        "type": "string"
+                                    },
+                                    "count": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "count",
+                                    "eventType"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "eventType",
+                    "incomingEventSets",
+                    "outgoingEventSets"
+                ]
+            }
+        }
+    },
+    "required": [
+        "events",
+        "job_name"
+    ]
+}
+```
+
+An example derived using the data in the [end-to-end walkthrough](/docs/e2e_walkthrough/example_pv_event_sequence_files) is shown below
+
+```json 
+{
+    "job_name": "Users_Service",
+    "events": [
+        {
+            "eventType": "return_response_200",
+            "outgoingEventSets": [],
+            "incomingEventSets": [
+                [{"eventType": "fetch_user_data_200", "count": 1}],
+                [{"eventType": "request_data_200", "count": 1}]
+            ]
+        },
+        {
+            "eventType": "fetch_user_data_200",
+            "outgoingEventSets": [
+                [{"eventType": "return_response_200", "count": 1}]
+            ],
+            "incomingEventSets": [
+                [{"eventType": "authorization_check_200", "count": 1}]
+            ]
+        },
+        {
+            "eventType": "authorization_check_200",
+            "outgoingEventSets": [
+                [{"eventType": "fetch_user_data_200", "count": 1}],
+                [{"eventType": "authorization_check_200", "count": 1}]
+            ],
+            "incomingEventSets": [
+                [{"eventType": "user_login_200", "count": 1}],
+                [{"eventType": "authorization_check_200", "count": 1}]
+            ]
+        },
+        {
+            "eventType": "user_login_200",
+            "outgoingEventSets": [
+                [{"eventType": "authenticate_credentials_200", "count": 1}],
+                [{"eventType": "authorization_check_200", "count": 1}]
+            ],
+            "incomingEventSets": [
+                [{"eventType": "|||START|||", "count": 1}]
+            ]
+        },
+        {
+            "eventType": "|||START|||",
+            "outgoingEventSets": [
+                [{"eventType": "user_login_200", "count": 1}]
+            ],
+            "incomingEventSets": []
+        },
+        {
+            "eventType": "request_data_200",
+            "outgoingEventSets": [
+                [{"eventType": "return_response_200", "count": 1}]
+            ],
+            "incomingEventSets": [
+                [{"eventType": "session_expired_200", "count": 1}],
+                [{"eventType": "validate_session_200", "count": 1}]
+            ]
+        },
+        {
+            "eventType": "validate_session_200",
+            "outgoingEventSets": [
+                [{"eventType": "authenticate_credentials_200","count": 1}],
+                [{"eventType": "request_data_200", "count": 1}]
+            ],
+            "incomingEventSets": [
+                [{"eventType": "authenticate_credentials_200", "count": 1}]
+            ]
+        },
+        {
+            "eventType": "authenticate_credentials_200",
+            "outgoingEventSets": [
+                [{"eventType": "session_expired_200", "count": 1}],
+                [{"eventType": "validate_session_200", "count": 1}]
+            ],
+            "incomingEventSets": [
+                [{"eventType": "user_login_200", "count": 1}],
+                [{"eventType": "session_expired_200", "count": 1}],
+                [{"eventType": "validate_session_200", "count": 1}]
+            ]
+        },
+        {
+            "eventType": "session_expired_200",
+            "outgoingEventSets": [
+                [{"eventType": "authenticate_credentials_200", "count": 1}],
+                [{"eventType": "request_data_200", "count": 1}]
+            ],
+            "incomingEventSets": [
+                [{"eventType": "authenticate_credentials_200", "count": 1}]
+            ]
+        }
+    ]
+}
+```

--- a/tel2puml/__main__.py
+++ b/tel2puml/__main__.py
@@ -70,17 +70,18 @@ parser.add_argument(
 input_output_parent_parser = argparse.ArgumentParser(add_help=False)
 
 input_output_parent_parser.add_argument(
-    "-i",
+    "-im",
     "--input-puml-models",
     metavar="input_puml_models",
-    help="Input puml models",
+    help="Input puml models file paths. Can be used multiple times",
     action="append",
     dest="input_puml_models",
     required=False,
+    default=[],
 )
 
 input_output_parent_parser.add_argument(
-    "-o",
+    "-om",
     "--output-puml-models",
     help="Flag to indicate whether to save puml models",
     action="store_true",

--- a/tel2puml/events.py
+++ b/tel2puml/events.py
@@ -568,6 +568,7 @@ class EventInput(BaseModel):
 
 
 class EventInputsFile(BaseModel):
+    """Class to store the input for a file of events."""
     job_name: str
     events: list[EventInput]
 

--- a/tel2puml/otel_to_puml.py
+++ b/tel2puml/otel_to_puml.py
@@ -60,7 +60,7 @@ def otel_to_puml(
     if global_options is not None:
         input_puml_models = global_options["input_puml_models"]
         for input_puml_model in input_puml_models:
-            job_name, events = load_events_from_file(input_puml_model)
+            job_name, events = load_events_from_file(str(input_puml_model))
             events_to_jobs_map[job_name] = events
     else:
         global_options = GlobalOptions(

--- a/tel2puml/otel_to_puml.py
+++ b/tel2puml/otel_to_puml.py
@@ -7,18 +7,25 @@ from typing import Generator, Optional, Literal, Any, Union
 
 from tqdm import tqdm
 
-from tel2puml.tel2puml_types import OtelPVOptions, PVEvent, PVPumlOptions
+from tel2puml.tel2puml_types import (
+    OtelPVOptions,
+    PVEvent,
+    PVPumlOptions,
+    GlobalOptions,
+)
 from tel2puml.otel_to_pv.otel_to_pv import otel_to_pv
 from tel2puml.pv_to_puml.pv_to_puml import (
     pv_streams_to_puml_files,
     pv_files_to_pv_streams,
 )
 from tel2puml.utils import wrap_generator_with_tqdm_start_and_end_messages
+from tel2puml.events import Event, load_events_from_file
 
 
 def otel_to_puml(
     otel_to_pv_options: Optional[OtelPVOptions] = None,
     pv_to_puml_options: Optional[PVPumlOptions] = None,
+    global_options: Optional[GlobalOptions] = None,
     output_file_directory: str = "puml_output",
     components: Literal["otel2puml", "otel2pv", "pv2puml"] = "otel2puml",
 ) -> None:
@@ -48,6 +55,18 @@ def otel_to_puml(
         except OSError as e:
             getLogger(__name__).error(f"Error creating directory.{e}")
             return
+    # check global options for input events file
+    events_to_jobs_map: dict[str, dict[str, Event]] = {}
+    if global_options is not None:
+        input_puml_models = global_options["input_puml_models"]
+        for input_puml_model in input_puml_models:
+            job_name, events = load_events_from_file(input_puml_model)
+            events_to_jobs_map[job_name] = events
+    else:
+        global_options = GlobalOptions(
+            input_puml_models=[],
+            output_puml_models=False,
+        )
 
     tqdm.write(f"Processing command: {components}...")
 
@@ -84,7 +103,7 @@ def otel_to_puml(
                 (
                     "All ingested OpenTelemetry data converted to PVEvents "
                     "and streamed."
-                )
+                ),
             )
             if components == "otel2pv":
                 tqdm.write(
@@ -110,5 +129,10 @@ def otel_to_puml(
             )
     # Convert streams to puml files
     tqdm.write(f"Saving PUML files to '{output_file_directory}'...")
-    pv_streams_to_puml_files(pv_streams, output_file_directory)
+    pv_streams_to_puml_files(
+        pv_streams,
+        output_file_directory,
+        events_to_jobs_map,
+        global_options.get("output_puml_models", False),
+    )
     tqdm.write("PUML files successfully generated!")

--- a/tel2puml/pv_to_puml/data_ingestion.py
+++ b/tel2puml/pv_to_puml/data_ingestion.py
@@ -232,7 +232,7 @@ def update_and_create_events_from_graph_solutions(
     :rtype: `dict`[`str`, :class:`Event`]
     """
     if events is None:
-        events: dict[str, Event] = {}
+        events = {}
     for graph_solution in graph_solutions:
         update_and_create_events_from_graph_solution(graph_solution, events)
     return events

--- a/tel2puml/pv_to_puml/data_ingestion.py
+++ b/tel2puml/pv_to_puml/data_ingestion.py
@@ -219,16 +219,20 @@ def update_and_create_events_from_graph_solution(
 
 def update_and_create_events_from_graph_solutions(
     graph_solutions: Iterable[GraphSolution],
+    events: dict[str, Event] | None = None,
 ) -> dict[str, Event]:
     """This function updates and creates events from an iterable of graph
     solutions.
 
     :param graph_solutions: An iterable of graph solutions.
     :type graph_solutions: `Iterable`[:class:`GraphSolution`]
+    :param events: The dictionary of events, defaults to None.
+    :type events: `dict`[`str`, :class:`Event`] | `None`, optional
     :return: A dictionary of events.
     :rtype: `dict`[`str`, :class:`Event`]
     """
-    events: dict[str, Event] = {}
+    if events is None:
+        events: dict[str, Event] = {}
     for graph_solution in graph_solutions:
         update_and_create_events_from_graph_solution(graph_solution, events)
     return events
@@ -237,6 +241,7 @@ def update_and_create_events_from_graph_solutions(
 def update_and_create_events_from_clustered_pvevents(
     clustered_events: Iterable[Iterable[PVEvent]],
     add_dummy_start: bool = False,
+    events: dict[str, Event] | None = None,
 ) -> dict[str, Event]:
     """This function updates and creates events from a sequence of clustered PV
     events.
@@ -245,6 +250,8 @@ def update_and_create_events_from_clustered_pvevents(
     :type clustered_events: `Iterable`[`Iterable`[:class:`PVEvent`]]
     :param add_dummy_start: Whether to add a dummy start event.
     :type add_dummy_start: `bool`
+    :param events: The dictionary of events, defaults to None.
+    :type events: `dict`[`str`, :class:`Event`] | `None`, optional
     :return: A dictionary of events.
     :rtype: `dict`[`str`, :class:`Event`]
     """
@@ -252,4 +259,7 @@ def update_and_create_events_from_clustered_pvevents(
         clustered_events,
         add_dummy_start=add_dummy_start,
     )
-    return update_and_create_events_from_graph_solutions(graph_solutions)
+    return update_and_create_events_from_graph_solutions(
+        graph_solutions,
+        events
+    )

--- a/tel2puml/pv_to_puml/pv_to_puml.py
+++ b/tel2puml/pv_to_puml/pv_to_puml.py
@@ -5,6 +5,7 @@ diagram, inferring the logic from the PV event sequences.
 from typing import Generator, Iterable, Any, Optional
 import json
 import os
+from copy import deepcopy
 
 from tqdm import tqdm
 
@@ -65,7 +66,10 @@ def pv_to_puml_string(
     events = update_and_create_events_from_clustered_pvevents(
         pv_stream, add_dummy_start=True, events=events
     )
-    initial_events_graph = create_graph_from_events(events.values())
+    events_for_calculations = deepcopy(events)
+    initial_events_graph = create_graph_from_events(
+        events_for_calculations.values()
+    )
     # detect loops
     nested_loop_event_graph = detect_loops(initial_events_graph)
     # convert graph to Node graph

--- a/tel2puml/tel2puml_types.py
+++ b/tel2puml/tel2puml_types.py
@@ -175,7 +175,7 @@ class OtelSpan(TypedDict):
 class GlobalOptions(TypedDict):
     """Typed dict for global options"""
 
-    input_puml_models: list[str]
+    input_puml_models: list[FilePath]
     output_puml_models: bool
 
 
@@ -302,7 +302,8 @@ class PvToPumlArgs(BaseModel):
 
 
 class GlobalArgs(BaseModel):
-
+    """Pydantic model for shared CLI arguments for otel2puml, otel2pv, and
+    pv2puml."""
     command: Literal["otel2puml", "otel2pv", "pv2puml"] = Field(
         ..., description="Command used within CLI"
     )

--- a/tests/tel2puml/otel_to_puml/conftest.py
+++ b/tests/tel2puml/otel_to_puml/conftest.py
@@ -407,3 +407,88 @@ def mock_job_json_file() -> list[dict[str, Any]]:
             "previousEventIds": ["evt_002"],
         },
     ]
+
+
+@pytest.fixture
+def mock_event_model() -> dict[str, Any]:
+    """Fixture to mock event model."""
+    return {
+        "job_name": "Frontend_TestJob",
+        "events": [
+            {
+                "eventType": "TestEvent",
+                "outgoingEventSets": [],
+                "incomingEventSets": [
+                    [{"eventType": "com.T2h.366Yx_500", "count": 1}]
+                ],
+            },
+            {
+                "eventType": "com.T2h.366Yx_500",
+                "outgoingEventSets": [
+                    [{"eventType": "TestEvent", "count": 1}]
+                ],
+                "incomingEventSets": [],
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def mock_job_json_file_for_event_model() -> list[dict[str, Any]]:
+    return [
+        {
+            "eventId": "evt_001",
+            "eventType": "com.C36.9ETRp_401",
+            "jobId": "job_id_001",
+            "timestamp": "2024-09-01T07:45:00Z",
+            "applicationName": "BackupService",
+            "jobName": "Frontend_TestJob",
+        },
+        {
+            "eventId": "evt_002",
+            "eventType": "com.T2h.366Yx_500",
+            "jobId": "job_id_001",
+            "timestamp": "2024-09-01T08:15:00Z",
+            "applicationName": "BackupService",
+            "jobName": "Frontend_TestJob",
+            "previousEventIds": ["evt_001"],
+        },
+    ]
+
+
+@pytest.fixture
+def expected_model_output() -> list[dict[str, Any]]:
+    return sorted([
+        {
+            "eventType": "|||START|||",
+            "outgoingEventSets": [
+                [{"eventType": "com.C36.9ETRp_401", "count": 1}]
+            ],
+            "incomingEventSets": [],
+        },
+        {
+            "eventType": "com.C36.9ETRp_401",
+            "outgoingEventSets": [
+                [{"eventType": "com.T2h.366Yx_500", "count": 1}]
+            ],
+            "incomingEventSets": [
+                [{"eventType": "|||START|||", "count": 1}]
+            ],
+        },
+        {
+            "eventType": "com.T2h.366Yx_500",
+            "outgoingEventSets": [
+                [{"eventType": "TestEvent", "count": 1}]
+            ],
+            "incomingEventSets": [
+                [{"eventType": "com.C36.9ETRp_401", "count": 1}]
+            ],
+        },
+        {
+            "eventType": "TestEvent",
+            "outgoingEventSets": [],
+            "incomingEventSets": [
+                [{"eventType": "com.T2h.366Yx_500", "count": 1}]
+            ],
+        },
+    ], key=lambda x: x["eventType"])

--- a/tests/tel2puml/otel_to_puml/conftest.py
+++ b/tests/tel2puml/otel_to_puml/conftest.py
@@ -435,6 +435,7 @@ def mock_event_model() -> dict[str, Any]:
 
 @pytest.fixture
 def mock_job_json_file_for_event_model() -> list[dict[str, Any]]:
+    """Fixture to mock job json file for event model."""
     return [
         {
             "eventId": "evt_001",
@@ -458,6 +459,7 @@ def mock_job_json_file_for_event_model() -> list[dict[str, Any]]:
 
 @pytest.fixture
 def expected_model_output() -> list[dict[str, Any]]:
+    """Fixture for expected model output."""
     return sorted([
         {
             "eventType": "|||START|||",

--- a/tests/tel2puml/otel_to_puml/test_otel_to_puml.py
+++ b/tests/tel2puml/otel_to_puml/test_otel_to_puml.py
@@ -461,7 +461,7 @@ class TestOtelToPuml:
         input_puml_models_file = tmp_path / "input_puml_models.json"
         input_puml_models_file.write_text(json.dumps(mock_event_model))
         global_options: GlobalOptions = {
-            "input_puml_models": [str(input_puml_models_file)],
+            "input_puml_models": [input_puml_models_file],
             "output_puml_models": output_puml_models,
         }
 
@@ -533,14 +533,15 @@ class TestOtelToPuml:
         data_file.write_text(json.dumps(mock_job_json_file_for_event_model))
         data_files = [str(data_file)]
 
-        pv_to_puml_options: PVPumlOptions = {
-            "file_list": data_files,
-            "job_name": "Frontend_TestJob",
-        }
+        pv_to_puml_options: PVPumlOptions = PVPumlOptions(
+            file_list=data_files,
+            job_name="Frontend_TestJob",
+            group_by_job_id=False,
+        )
         input_puml_models_file = tmp_path / "input_puml_models.json"
         input_puml_models_file.write_text(json.dumps(mock_event_model))
         global_options: GlobalOptions = {
-            "input_puml_models": [str(input_puml_models_file)],
+            "input_puml_models": [input_puml_models_file],
             "output_puml_models": output_puml_models,
         }
 

--- a/tests/tel2puml/pv_to_puml/test_pv_to_puml.py
+++ b/tests/tel2puml/pv_to_puml/test_pv_to_puml.py
@@ -142,12 +142,7 @@ def test_pv_streams_to_puml_files(
     )
     # Check that the expected files are created in temp_dir
     expected_files = ["Job_A.puml", "Job_B.puml"]
-    expected_output_model = sorted([
-        {
-            "eventType": "|||START|||",
-            "incomingEventSets": [],
-            "outgoingEventSets": [[{"eventType": "A", "count": 1}]],
-        },
+    expected_output_model = [
         {
             "eventType": "A",
             "incomingEventSets": [[{"eventType": "|||START|||", "count": 1}]],
@@ -168,7 +163,12 @@ def test_pv_streams_to_puml_files(
             "incomingEventSets": [[{"eventType": "C", "count": 1}]],
             "outgoingEventSets": [],
         },
-    ], key=lambda x: x["eventType"])
+        {
+            "eventType": "|||START|||",
+            "incomingEventSets": [],
+            "outgoingEventSets": [[{"eventType": "A", "count": 1}]],
+        },
+    ]
     for idx, expected_file in enumerate(expected_files):
         file_path = os.path.join(temp_dir, expected_file)
         assert os.path.exists(file_path)

--- a/tests/tel2puml/pv_to_puml/test_pv_to_puml.py
+++ b/tests/tel2puml/pv_to_puml/test_pv_to_puml.py
@@ -122,6 +122,7 @@ def test_pv_event_files_to_job_id_streams(
     ) == sorted(mock_job_json_file, key=lambda x: x["eventId"])
 
 
+@pytest.mark.parametrize("save_models", [True, False])
 def test_pv_streams_to_puml_files(
     pv_streams: Generator[
         tuple[str, Generator[Generator[PVEvent, Any, None], Any, None]],
@@ -129,14 +130,45 @@ def test_pv_streams_to_puml_files(
         None,
     ],
     tmp_path: Path,
+    save_models: bool,
 ) -> None:
     """Tests the function pv_streams_to_puml_files"""
     # Create temp directory for puml files
     temp_dir = os.path.join(str(tmp_path), "temp_dir")
     os.makedirs(temp_dir)
-    pv_streams_to_puml_files(pv_streams, output_file_directory=temp_dir)
+    pv_streams_to_puml_files(
+        pv_streams, output_file_directory=temp_dir,
+        save_models=save_models,
+    )
     # Check that the expected files are created in temp_dir
     expected_files = ["Job_A.puml", "Job_B.puml"]
+    expected_output_model = sorted([
+        {
+            "eventType": "|||START|||",
+            "incomingEventSets": [],
+            "outgoingEventSets": [[{"eventType": "A", "count": 1}]],
+        },
+        {
+            "eventType": "A",
+            "incomingEventSets": [[{"eventType": "|||START|||", "count": 1}]],
+            "outgoingEventSets": [[{"eventType": "B", "count": 1}]],
+        },
+        {
+            "eventType": "B",
+            "incomingEventSets": [[{"eventType": "A", "count": 1}]],
+            "outgoingEventSets": [[{"eventType": "C", "count": 1}]],
+        },
+        {
+            "eventType": "C",
+            "incomingEventSets": [[{"eventType": "B", "count": 1}]],
+            "outgoingEventSets": [[{"eventType": "D", "count": 1}]],
+        },
+        {
+            "eventType": "D",
+            "incomingEventSets": [[{"eventType": "C", "count": 1}]],
+            "outgoingEventSets": [],
+        },
+    ], key=lambda x: x["eventType"])
     for idx, expected_file in enumerate(expected_files):
         file_path = os.path.join(temp_dir, expected_file)
         assert os.path.exists(file_path)
@@ -160,6 +192,22 @@ def test_pv_streams_to_puml_files(
             content = content.strip()
             expected_content = expected_content.strip()
             assert content == expected_content
+        if save_models:
+            expected_model_file = os.path.join(
+                temp_dir, f"{expected_job_name}_model.json"
+            )
+            assert os.path.exists(expected_model_file)
+            with open(expected_model_file, "r") as f:
+                model_content = json.load(f)
+                assert "job_name" in model_content
+                assert model_content["job_name"] == expected_job_name
+                assert "events" in model_content
+                assert (
+                    sorted(
+                        model_content["events"], key=lambda x: x["eventType"]
+                    )
+                    == expected_output_model
+                )
 
 
 @pytest.mark.parametrize("group_by_job_id", [True, False])

--- a/tests/tel2puml/test_events.py
+++ b/tests/tel2puml/test_events.py
@@ -272,7 +272,7 @@ class TestEventInputIngestAndOutput:
     @staticmethod
     def raw_event_input() -> list[dict[str, Any]]:
         """Return a list of raw event inputs."""
-        return [
+        return sorted([
             {
                 "eventType": "A",
                 "outgoingEventSets": [
@@ -299,12 +299,12 @@ class TestEventInputIngestAndOutput:
                     [{"eventType": "B", "count": 1}],
                 ],
             },
-        ]
+        ], key=lambda x: x["eventType"])
 
     @staticmethod
     def event_input() -> list[EventInput]:
         """Return a list of event inputs."""
-        return [
+        return sorted([
             EventInput(
                 eventType="A",
                 outgoingEventSets=[
@@ -331,7 +331,7 @@ class TestEventInputIngestAndOutput:
                     [EventSetCountInput(eventType="B", count=1)]
                 ],
             ),
-        ]
+        ], key=lambda x: x.eventType)
 
     def events(self) -> dict[str, Event]:
         """Return a dictionary of events."""
@@ -390,6 +390,13 @@ class TestEventInputIngestAndOutput:
         event_inputs = sorted(
             events_to_event_inputs(events), key=lambda x: x.eventType
         )
+        for event_input in event_inputs:
+            event_input.outgoingEventSets = sorted(
+                event_input.outgoingEventSets, key=lambda x: x[0].eventType
+            )
+            event_input.incomingEventSets = sorted(
+                event_input.incomingEventSets, key=lambda x: x[0].eventType
+            )
         assert event_inputs == self.event_input()
 
     def test_raw_input_to_events(self) -> None:
@@ -414,4 +421,13 @@ class TestEventInputIngestAndOutput:
         raw_event_input = sorted(
             events_to_raw_input(events), key=lambda x: x["eventType"]
         )
+        for event_input in raw_event_input:
+            event_input["outgoingEventSets"] = sorted(
+                event_input["outgoingEventSets"],
+                key=lambda x: x[0]["eventType"]
+            )
+            event_input["incomingEventSets"] = sorted(
+                event_input["incomingEventSets"],
+                key=lambda x: x[0]["eventType"]
+            )
         assert raw_event_input == self.raw_event_input()


### PR DESCRIPTION
This PR merges in functionality to save and load the internal data models that the PUML files are derived from. This allows the user to be able to save a model and then load it to update with new information:

It is useful in the case where the dataset used is large and has many events so that a model can be built up using chunks of data of smaller sizes.